### PR TITLE
エラーメッセージの日本語化

### DIFF
--- a/ads
+++ b/ads
@@ -1,0 +1,14 @@
+  create_post[m
+  deploy[m
+  er[m
+  fix_readme[m
+  initial-setup[m
+* [32mjapanese_validates[m
+  main[m
+  re_fix_readme[m
+  readme[m
+  redirect_top[m
+  restoration_readme[m
+  setup/initial-configuration[m
+  std[m
+  user_registration[m

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -47,7 +47,7 @@ class Post < ApplicationRecord
     return if content.blank?
     
     unless content.match?(/\A[ぁ-んァ-ン゛゜ー・、。　\s]*\z/)
-      errors.add(:base, "ひらがな・カタカナのみ使用できます")
+      errors.add(:base, :kana_only)
       return
     end
   end
@@ -58,9 +58,9 @@ class Post < ApplicationRecord
     
     syllable_count = count_syllables(content)
     if syllable_count == 0
-      errors.add(:base, "句を入力してください")
+      errors.add(:base, :syllable_blank)
     elsif syllable_count > 20
-      errors.add(:base, "20音以下で入力してください（現在: #{syllable_count}音）")
+      errors.add(:base, :syllable_count, count: 20, current: syllable_count)
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,12 +11,15 @@ module App
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.time_zone = 'Tokyo'
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,71 @@
+ja:
+  activerecord:
+    models:
+      user: 'ユーザー'
+      post: '句'
+    attributes:
+      user:
+        name: '名前'
+        email: 'メールアドレス'
+        password: 'パスワード'
+        password_confirmation: 'パスワード確認'
+      post:
+        content: '内容'
+        base: '' # baseエラーメッセージ用
+    errors:
+      models:
+        user:
+          attributes:
+            name:
+              blank: 'を入力してください'
+            email:
+              blank: 'を入力してください'
+              taken: 'は既に使用されています'
+            password:
+              blank: 'を入力してください'
+              too_short: 'は%{count}文字以上で入力してください'
+            password_confirmation:
+              blank: 'を入力してください'
+              confirmation: 'とパスワードの入力が一致しません'
+        post:
+          attributes:
+            content:
+              blank: 'を入力してください'
+            base:
+              kana_only: 'ひらがな・カタカナのみ使用できます'
+              syllable_blank: '句を入力してください'
+              syllable_count: '%{count}音以下で入力してください（現在: %{current}音）'
+
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M"
+      long: "%Y年%m月%d日 %H時%M分"
+      short: "%m/%d %H:%M"
+    am: "午前"
+    pm: "午後"
+  
+  date:
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    day_names: [日曜日, 月曜日, 火曜日, 水曜日, 木曜日, 金曜日, 土曜日]
+    abbr_day_names: [日, 月, 火, 水, 木, 金, 土]
+    month_names: [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
+    abbr_month_names: [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
+    order:
+      - :year
+      - :month
+      - :day
+
+  flash:
+    success:
+      user_created: 'ユーザー登録が完了しました'
+      login: 'ログインしました'
+      logout: 'ログアウトしました'
+      post_created: '句を投稿しました'
+      post_deleted: '句を削除しました'
+    error:
+      login: 'ログインに失敗しました'
+      post_create: '句の投稿に失敗しました'
+      default: '入力内容を確認してください'


### PR DESCRIPTION
# 概要
エラーメッセージの日本語化を行いました。

## 実装内容

## 日本語化の実装
- バリデーションメッセージの日本語化
  - ユーザー登録時のエラーメッセージ
  - 句の投稿時のエラーメッセージ
- 日時フォーマットの日本語化
  - 投稿日時の表示を「○○年○○月○○日 ○○時○○分」形式に変更
- フラッシュメッセージの日本語化
  - ログイン/ログアウト時のメッセージ
  - 投稿/削除時のメッセージ

# 動作確認方法
- ブラウザ上でのテストで動作を確認