### PR TITLE
パスワードの説明

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -25,7 +25,7 @@
         </div>
 
         <div class="mb-3">
-          <%= f.label :password, 'パスワード', class: 'form-label' %>
+          <%= f.label :password, 'パスワード(3文字以上)', class: 'form-label' %>
           <%= f.password_field :password, class: 'form-control' %>
         </div>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -23,7 +23,7 @@ ja:
               taken: 'は既に使用されています'
             password:
               blank: 'を入力してください'
-              too_short: 'は%{count}文字以上で入力してください'
+              too_short: 'は3文字以上で入力してください'
             password_confirmation:
               blank: 'を入力してください'
               confirmation: 'とパスワードの入力が一致しません'


### PR DESCRIPTION
[![Image from Gyazo](https://i.gyazo.com/1cdb0338275297420134f73b5a7d753d.png)](https://gyazo.com/1cdb0338275297420134f73b5a7d753d)
# 概要
パスワードの文字数要件をユーザーに明示的に表示するように修正しました。

## 実装内容
- パスワード入力フィールドのラベルに文字数制限を追加
  - 「パスワード」→「パスワード(3文字以上)」に変更
- エラーメッセージを具体的な表現に修正
  - パスワード文字数不足時のエラーメッセージを日本語で明確に表示

## 動作確認方法
 ブラウザ上でのテストで動作を確認

MVPリリース後、パスワード強度を引き上げることを想定しています