### PR TITLE
俳句と川柳のタグ付け

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
   before_action :ensure_correct_user, only: [:destroy]
 
   def index
-    @posts = Post.order(created_at: :desc)
+    @posts = Post.includes(:user, :tags).order(created_at: :desc)
   end
 
   def show
@@ -12,11 +12,16 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
+    @tags = Tag.all
   end
 
   def create
     @post = current_user.posts.build(post_params)
+    @tags = Tag.all
     @current_count = @post.count_syllables(post_params[:content])
+
+    tag = Tag.find_by(id: params[:post][:tag_id])
+    @post.tags << tag if tag
 
     if @post.save
       redirect_to posts_path, notice: '句を投稿しました'

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,9 +1,12 @@
 class Post < ApplicationRecord
   belongs_to :user
+  has_many :post_tags, dependent: :destroy
+  has_many :tags, through: :post_tags
 
   validates :content, presence: true
   validate :kana_only_validation
   validate :syllable_count_validation
+  validate :tag_presence_validation
 
   # privateからpublicに移動
   def count_syllables(text)
@@ -61,6 +64,14 @@ class Post < ApplicationRecord
       errors.add(:base, :syllable_blank)
     elsif syllable_count > 20
       errors.add(:base, :syllable_count, count: 20, current: syllable_count)
+    end
+  end
+
+  def tag_presence_validation
+    if tags.empty?
+      errors.add(:base, :tag_required)
+    elsif tags.count > 1
+      errors.add(:base, :one_tag_only)
     end
   end
 end

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,0 +1,6 @@
+class PostTag < ApplicationRecord
+  belongs_to :post
+  belongs_to :tag
+
+  validates :post_id, uniqueness: { scope: :tag_id }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,6 @@
+class Tag < ApplicationRecord
+  has_many :post_tags, dependent: :destroy
+  has_many :posts, through: :post_tags
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -6,8 +6,11 @@
         <%= link_to post_path(post), class: "text-decoration-none" do %>
           <div class="card mb-3">
             <div class="card-body">
+              <div class="d-flex justify-content-between align-items-start mb-2">
+                <span class="badge bg-primary"><%= post.tags.first&.name %></span>
+                <small class="text-muted"><%= l post.created_at, format: :long %></small>
+              </div>
               <p class="card-text"><%= post.content %></p>
-              <small class="text-muted"><%= l post.created_at, format: :long %></small>
             </div>
           </div>
         <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -10,12 +10,23 @@
             <li>・ひらがな・カタカナのみ使用できます</li>
             <li>・17音前後で入力してください</li>
             <li>・句読点（、。）や空白は使用できます</li>
+            <li>・俳句か川柳を選択してください</li>
           </ul>
         </div>
       </div>
 
       <%= form_with(model: @post, local: true) do |f| %>
         <div class="mb-3">
+          <label class="form-label">種類を選択</label>
+          <div class="d-flex gap-4 mb-3">
+            <% @tags.each do |tag| %>
+              <div class="form-check">
+                <%= f.radio_button :tag_id, tag.id, class: "form-check-input" %>
+                <%= f.label "tag_id_#{tag.id}", tag.name, class: "form-check-label" %>
+              </div>
+            <% end %>
+          </div>
+
           <%= f.text_area :content, 
               class: "form-control #{'is-invalid' if flash[:alert]}", 
               rows: 3,

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       user: 'ユーザー'
       post: '句'
+      tag: 'タグ'
     attributes:
       user:
         name: '名前'
@@ -12,6 +13,8 @@ ja:
       post:
         content: '内容'
         base: '' # baseエラーメッセージ用
+      tag:
+        name: 'タグ名'
     errors:
       models:
         user:
@@ -35,6 +38,8 @@ ja:
               kana_only: 'ひらがな・カタカナのみ使用できます'
               syllable_blank: '句を入力してください'
               syllable_count: '%{count}音以下で入力してください（現在: %{current}音）'
+              tag_required: '俳句か川柳を選択してください'
+              one_tag_only: '俳句か川柳のどちらか1つのみ選択できます'
 
   time:
     formats:

--- a/db/migrate/20241202011329_create_tags.rb
+++ b/db/migrate/20241202011329_create_tags.rb
@@ -1,0 +1,11 @@
+class CreateTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    add_index :tags, :name, unique: true
+  end
+end

--- a/db/migrate/20241202011422_create_post_tags.rb
+++ b/db/migrate/20241202011422_create_post_tags.rb
@@ -1,0 +1,12 @@
+class CreatePostTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :post_tags do |t|
+      t.references :post, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :post_tags, [:post_id, :tag_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_21_050407) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_02_011422) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "post_tags", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id", "tag_id"], name: "index_post_tags_on_post_id_and_tag_id", unique: true
+    t.index ["post_id"], name: "index_post_tags_on_post_id"
+    t.index ["tag_id"], name: "index_post_tags_on_tag_id"
+  end
 
   create_table "posts", force: :cascade do |t|
     t.text "content"
@@ -20,6 +30,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_21_050407) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -32,5 +49,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_21_050407) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "post_tags", "posts"
+  add_foreign_key "post_tags", "tags"
   add_foreign_key "posts", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,3 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+# 俳句と川柳のタグを作成
+Tag.find_or_create_by!(name: '俳句')
+Tag.find_or_create_by!(name: '川柳')

--- a/test/fixtures/post_tags.yml
+++ b/test/fixtures/post_tags.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  post: one
+  tag: one
+
+two:
+  post: two
+  tag: two

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/post_tag_test.rb
+++ b/test/models/post_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 概要
俳句と川柳を区別するためのタグ機能を実装しました。

## 実装内容
### タグ機能の実装
- モデルの作成と関連付け
 - Tagモデル（タグの基本情報を管理）
 - PostTagモデル（投稿とタグの中間テーブル）
 - 各モデル間のアソシエーションの設定

- タグに関するバリデーション
 - 投稿時にタグ選択を必須化
 - 一つの投稿に対して一つのタグのみ設定可能
 - 「俳句」「川柳」のいずれかを選択必須

- UIの実装
 - 投稿フォームにラジオボタンでタグ選択機能を追加
 - 投稿一覧にタグをバッジ表示
 - タグ関連のエラーメッセージを日本語化

### シードデータの追加
- 「俳句」「川柳」の初期タグデータを作成

## 動作確認方法
以下の点をブラウザ上で確認
- 新規投稿時にタグ（俳句/川柳）の選択が必須
- タグを選択せずに投稿した場合、適切なエラーメッセージが表示される
- 投稿一覧で各投稿に選択したタグが表示される
- 複数のユーザーでログインし、それぞれのタグ付き投稿が正常に表示される

## 補足
- 今後の拡張性を考慮し、中間テーブルを使用した設計を採用
- UIはシンプルさを重視し、ラジオボタンで実装