### PR TITLE
ログアウトボタンを移動

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,11 +28,6 @@
               <% end %>
             </div>
             <%= link_to '句を詠む', new_post_path, class: 'button button-success' %>
-            <%= button_to 'ログアウト', 
-                logout_path, 
-                method: :delete,
-                class: 'button',
-                data: { turbo: true } %>
           <% else %>
             <%= link_to 'ログイン', login_path, class: 'button' %>
             <%= link_to '新規登録', signup_path, class: 'button' %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -17,6 +17,11 @@
           <div class="mt-4">
             <%= link_to '編集', edit_profile_path, class: 'button me-2' %>
             <%= link_to 'パスワード変更', password_profile_path, class: 'button' %>
+            <%= button_to 'ログアウト', 
+                logout_path, 
+                method: :delete,
+                class: 'button',
+                data: { turbo: true } %>
           </div>
         </div>
       </div>


### PR DESCRIPTION

# 概要
ヘッダーにあったログアウトボタンをユーザープロフィールページに移動しました。

## 変更内容
- app/views/layouts/application.html.erb からログアウトボタンを削除
- app/views/profiles/show.html.erb にログアウトボタンを追加
- ボタンのスタイリングは既存のものを踏襲（button クラスを使用）

## 動作確認
- ローカル環境でログアウト機能の正常動作を確認済み