### PR TITLE
2段階入力に変更

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,6 +2,7 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import * as bootstrap from "bootstrap"
+import "./posts"
 
 document.addEventListener('turbo:load', () => {
   const flashMessages = document.querySelectorAll('.notice, .alert');

--- a/app/javascript/posts.js
+++ b/app/javascript/posts.js
@@ -1,0 +1,66 @@
+document.addEventListener('turbo:load', function() {
+  console.log("posts.js loaded");
+  
+  function initializeForm() {
+    const readingForm = document.getElementById('reading-form');
+    const contentForm = document.getElementById('content-form');
+    const nextButton = document.getElementById('next-step');
+    const backButton = document.getElementById('back-to-reading');
+    const readingInput = document.querySelector('textarea[name="post[reading]"]');
+    const contentInput = document.querySelector('textarea[name="post[display_content]"]');
+    const warningDisplay = document.getElementById('content-warning');
+    
+    console.log('Elements found:', {
+      readingForm: !!readingForm,
+      contentForm: !!contentForm,
+      nextButton: !!nextButton,
+      backButton: !!backButton
+    });
+
+    if (nextButton) {
+      nextButton.addEventListener('click', function(event) {
+        console.log('Next button clicked');
+        event.preventDefault();
+        
+        if (readingInput && readingInput.value.trim()) {
+          readingForm.style.display = 'none';
+          contentForm.style.display = 'block';
+          console.log('Switched to content form');
+        }
+      });
+    }
+
+    if (backButton) {
+      backButton.addEventListener('click', function(event) {
+        console.log('Back button clicked');
+        event.preventDefault();
+        contentForm.style.display = 'none';
+        readingForm.style.display = 'block';
+        console.log('Switched to reading form');
+      });
+    }
+
+    if (contentInput && readingInput && warningDisplay) {
+      contentInput.addEventListener('input', function() {
+        const reading = readingInput.value.replace(/[\s　、。]/g, '');
+        const content = contentInput.value.replace(/[\s　、。]/g, '');
+
+        if (content.length < (reading.length / 2)) {
+          warningDisplay.textContent = "本文が読みより短いようです。意図した入力ですか？";
+        } else if (content.length > (reading.length * 2)) {
+          warningDisplay.textContent = "本文が読みより長いようです。意図した入力ですか？";
+        } else {
+          warningDisplay.textContent = "";
+        }
+      });
+    }
+  }
+
+  initializeForm();
+
+  // Turboによるページ更新時にも初期化を実行
+  document.addEventListener('turbo:render', function() {
+    console.log('Turbo render occurred, reinitializing form');
+    initializeForm();
+  });
+});

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,7 +10,7 @@
                 <span class="badge bg-primary"><%= post.tags.first&.name %></span>
                 <small class="text-muted"><%= l post.created_at, format: :long %></small>
               </div>
-              <p class="card-text"><%= post.content %></p>
+              <p class="card-text"><%= post.display_content %></p>
             </div>
           </div>
         <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -3,6 +3,12 @@
     <div class="col-md-8">
       <h1 class="text-center mb-4">新しい句を詠む</h1>
 
+      <% if flash[:alert] %>
+        <div class="alert alert-danger">
+          <%= flash[:alert] %>
+        </div>
+      <% end %>
+
       <div class="card mb-4">
         <div class="card-body">
           <h2 class="h5 mb-3">投稿のルール</h2>
@@ -16,32 +22,58 @@
       </div>
 
       <%= form_with(model: @post, local: true) do |f| %>
-        <div class="mb-3">
-          <label class="form-label">種類を選択</label>
-          <div class="d-flex gap-4 mb-3">
-            <% @tags.each do |tag| %>
-              <div class="form-check">
-                <%= f.radio_button :tag_id, tag.id, class: "form-check-input" %>
-                <%= f.label "tag_id_#{tag.id}", tag.name, class: "form-check-label" %>
-              </div>
-            <% end %>
-          </div>
-
-          <%= f.text_area :content, 
-              class: "form-control #{'is-invalid' if flash[:alert]}", 
+        <%# Step 1: 読みの入力フォーム %>
+        <div id="reading-form" class="mb-3">
+          <label class="form-label">読み方（ひらがな・カタカナ）</label>
+          <%= f.text_area :reading, 
+              class: "form-control #{'is-invalid' if @post&.errors&.include?(:reading)}", 
               rows: 3,
               placeholder: "ひらがな・カタカナで入力してください" %>
           
-          <% if flash[:alert] %>
+          <% if @post&.errors&.include?(:reading) %>
             <div class="invalid-feedback">
-              <%= flash[:alert] %>
+              <%= @post.errors[:reading].first %>
             </div>
           <% end %>
+
+          <div class="text-center mt-3">
+            <button type="button" id="next-step" class="button button-primary">次へ</button>
+            <%= link_to "戻る", posts_path, class: 'button' %>
+          </div>
         </div>
 
-        <div class="text-center">
-          <%= f.submit "投稿する", class: 'button button-primary me-2' %>
-          <%= link_to "戻る", posts_path, class: 'button' %>
+        <%# Step 2: 本文と種類の入力フォーム（最初は非表示） %>
+        <div id="content-form" class="mb-3" style="display: none;">
+          <label class="form-label">本文</label>
+          <%= f.text_area :display_content, 
+              class: "form-control #{'is-invalid' if @post&.errors&.include?(:display_content)}", 
+              rows: 3,
+              placeholder: "本文を入力してください" %>
+          
+          <% if @post&.errors&.include?(:display_content) %>
+            <div class="invalid-feedback">
+              <%= @post.errors[:display_content].first %>
+            </div>
+          <% end %>
+
+          <div id="content-warning" class="text-warning mt-2"></div>
+
+          <div class="mt-4">
+            <label class="form-label">種類を選択</label>
+            <div class="d-flex gap-4 mb-3">
+              <% @tags.each do |tag| %>
+                <div class="form-check">
+                  <%= f.radio_button :tag_id, tag.id, class: "form-check-input" %>
+                  <%= f.label "tag_id_#{tag.id}", tag.name, class: "form-check-label" %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="text-center mt-3">
+            <button type="button" id="back-to-reading" class="button me-2">戻る</button>
+            <%= f.submit "投稿する", class: 'button button-primary' %>
+          </div>
         </div>
       <% end %>
     </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,7 +3,8 @@
     <div class="col-md-8">
       <div class="card mb-3">
         <div class="card-body">
-          <p class="card-text"><%= @post.content %></p>
+          <p class="card-text"><%= @post.display_content %></p>
+          <p class="card-text text-muted"><small>読み：<%= @post.reading %></small></p>
           <small class="text-muted"><%= l @post.created_at, format: :long %></small>
           
           <% if logged_in? && current_user == @post.user %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -35,7 +35,7 @@
                 <span class="badge bg-primary"><%= post.tags.first&.name %></span>
                 <small class="text-muted"><%= l post.created_at, format: :long %></small>
               </div>
-              <p class="card-text"><%= post.content %></p>
+              <p class="card-text"><%= post.display_content %></p>
             </div>
           </div>
         <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,8 +11,11 @@ ja:
         password: 'パスワード'
         password_confirmation: 'パスワード確認'
       post:
+        reading: '読み'
+        display_content: '本文'
         content: '内容'
         base: '' # baseエラーメッセージ用
+        post_tags: 'タグ'
       tag:
         name: 'タグ名'
     errors:
@@ -32,6 +35,12 @@ ja:
               confirmation: 'とパスワードの入力が一致しません'
         post:
           attributes:
+            reading:
+              kana_only_reading: 'ひらがな・カタカナのみ使用できます'
+              syllable_blank_reading: 'を入力してください'
+              blank: 'を入力してください'
+            display_content:
+              blank: 'を入力してください'
             content:
               blank: 'を入力してください'
             base:
@@ -40,7 +49,8 @@ ja:
               syllable_count: '%{count}音以下で入力してください（現在: %{current}音）'
               tag_required: '俳句か川柳を選択してください'
               one_tag_only: '俳句か川柳のどちらか1つのみ選択できます'
-
+              post_tags:
+                invalid: 'の選択が不正です'
   time:
     formats:
       default: "%Y/%m/%d %H:%M"

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,7 +15,7 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 3000 }
+bind ENV.fetch("BIND") { "tcp://0.0.0.0:3000" }
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/db/migrate/20241205015050_add_reading_to_posts.rb
+++ b/db/migrate/20241205015050_add_reading_to_posts.rb
@@ -1,0 +1,5 @@
+class AddReadingToPosts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :posts, :reading, :string, null: false
+  end
+end

--- a/db/migrate/20241205015119_rename_content_in_posts.rb
+++ b/db/migrate/20241205015119_rename_content_in_posts.rb
@@ -1,0 +1,5 @@
+class RenameContentInPosts < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :posts, :content, :display_content
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_04_044946) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_05_015119) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,10 +25,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_04_044946) do
   end
 
   create_table "posts", force: :cascade do |t|
-    t.text "content"
+    t.text "display_content"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "reading", null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
# 投稿機能の2段階入力方式への変更

## 概要
投稿の入力方式を2段階（読み→本文）に変更し、より使いやすい投稿システムを実装しました。また、投稿の表示方法を整理し、一覧性と詳細性のバランスを改善しました。

## 実装内容
### 投稿フォームの修正
- 投稿フォームを「読み」と「本文」の2段階入力方式に変更
- 読みはひらがな・カタカナのみ、本文は漢字等も使用可能に変更
- JavaScriptを用いたフォーム切り替え機能の実装

### データベースの変更
- `posts`テーブルに`reading`カラムを追加
- 既存の`content`カラムを`display_content`にリネーム

### 表示方法の整理
- 一覧画面（トップページ、マイページ）: 本文のみ表示
- 詳細画面: 本文と読みの両方を表示
- タグ（俳句/川柳）の選択機能を維持

## 変更理由
- 17音の判別を容易にするため、読みと本文を分離
- 表示の場面に応じて適切な情報量を提供
- 漢字等を使用可能にすることで表現の幅を拡大

## 動作確認項目
1. [x] 「読み」入力後、「次へ」ボタンで本文入力画面に遷移
2. [x] 読みはひらがな・カタカナのみ受付
3. [x] 本文は漢字・アルファベット等も入力可能
4. [x] 一覧画面では本文のみ表示
5. [x] 詳細画面では本文と読みの両方を表示