### PR TITLE
改行表示の実装

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -79,6 +79,11 @@
   }
 }
 
+.post-content {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
 // エラーメッセージ
 .error-message {
   color: #dc3545;

--- a/app/views/posts/confirm.html.erb
+++ b/app/views/posts/confirm.html.erb
@@ -17,7 +17,7 @@
 
           <div class="mb-4">
             <h2 class="h5 mb-2">本文</h2>
-            <p class="mb-0"><%= @post&.display_content %></p>
+            <p class="mb-0 post-content"><%= @post&.display_content %></p>
           </div>
         </div>
       </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,7 +10,7 @@
                 <span class="badge bg-primary"><%= post.tags.first&.name %></span>
                 <small class="text-muted"><%= l post.created_at, format: :long %></small>
               </div>
-              <p class="card-text"><%= post.display_content %></p>
+              <p class="card-text post-content"><%= post.display_content %></p>
             </div>
           </div>
         <% end %>

--- a/app/views/posts/new_content.html.erb
+++ b/app/views/posts/new_content.html.erb
@@ -13,7 +13,9 @@
 
       <%= form_with(model: @post, url: confirm_posts_path, method: :get, local: true) do |f| %>
         <div class="form-group mb-4">
-          <%= f.text_area :display_content, class: "form-control", rows: 3,
+          <%= f.text_area :display_content,
+              class: "form-control",
+              rows: 3,
               placeholder: "本文を入力してください" %>
           <%= f.hidden_field :reading, value: @post&.reading %>
           <%= f.hidden_field :tag_id, value: @tag&.id %>

--- a/app/views/posts/new_reading.html.erb
+++ b/app/views/posts/new_reading.html.erb
@@ -16,10 +16,10 @@
 
       <%= form_with(model: @post, url: new_content_posts_path, method: :get, local: true) do |f| %>
         <div class="form-group mb-4">
-          <%= f.text_area :reading,
+          <%= f.text_field :reading,
               class: "form-control",
               rows: 3,
-              placeholder: "ひらがな・カタカナで入力してください",
+              placeholder: "ひらがな・カタカナで入力してください（句切れは空白で入力）",
               data: { controller: "reading-validation" },
               required: true %>
         </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,7 +3,7 @@
     <div class="col-md-8">
       <div class="card mb-3">
         <div class="card-body">
-          <p class="card-text"><%= @post.display_content %></p>
+          <p class="card-text post-content"><%= @post.display_content %></p>
           <p class="card-text text-muted"><small>読み：<%= @post.reading %></small></p>
           <small class="text-muted"><%= l @post.created_at, format: :long %></small>
           

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -35,7 +35,7 @@
                 <span class="badge bg-primary"><%= post.tags.first&.name %></span>
                 <small class="text-muted"><%= l post.created_at, format: :long %></small>
               </div>
-              <p class="card-text"><%= post.display_content %></p>
+              <p class="card-text post-content"><%= post.display_content %></p>
             </div>
           </div>
         <% end %>


### PR DESCRIPTION
# 本文の改行機能の実装

## 概要
本文での改行入力を可能にし、各画面で改行を適切に表示する機能を実装しました。これにより、5-7-5の句の区切りをより視覚的に表現できるようになりました。

## 実装内容
### 改行表示機能の追加
- 本文表示時の改行対応のためのCSSクラス（post-content）を追加
- 以下の画面で改行表示を実装：
  - 句一覧画面
  - 句詳細画面
  - プロフィール画面
  - 確認画面

### 入力フォームの改善
- 読み方入力を1行入力（text_field）に変更
- 本文入力は改行可能なまま（text_area）を維持

## 変更理由
- 5-7-5の句の区切りを改行で視覚的に表現可能に
- 読み方は1行での入力に統一し、UIの一貫性を向上
- 表示時の可読性を向上

## 動作確認項目
1. [x] 本文での改行入力が可能
2. [x] 読み方は1行入力に制限
3. [x] 各画面での改行表示の一貫性
4. [x] 確認画面での改行表示