### PR TITLE
読み方入力時の空白の制限

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -18,12 +18,12 @@ class PostsController < ApplicationController
 
   def new_reading
     if params[:post] && params[:post][:tag_id].present?
-      session[:post_params] ||= {}
+      session[:post_params] ||= {} 
       session[:post_params]['tag_id'] = params[:post][:tag_id]
     end
   
     @post = Post.new(session[:post_params])
-    @tag = Tag.find_by(id: session[:post_params]['tag_id'])
+    @tag = Tag.find_by(id: session[:post_params]&.dig('tag_id'))
   
     redirect_to new_type_posts_path, alert: '句の種類を選択してください' unless @tag
   end

--- a/app/javascript/controllers/reading_validation_controller.js
+++ b/app/javascript/controllers/reading_validation_controller.js
@@ -1,17 +1,29 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
+  static targets = [ "input" ]
   connect() {
-    this.element.addEventListener('input', this.validate.bind(this))
-    this.element.addEventListener('paste', this.handlePaste.bind(this))
-    this.element.addEventListener('compositionend', this.validate.bind(this))
+    console.log('Reading validation controller connected')
+    console.log('Input target:', this.inputTarget)
+    this.inputTarget.addEventListener('input', this.validate.bind(this))
+    this.inputTarget.addEventListener('paste', this.handlePaste.bind(this))
+    this.inputTarget.addEventListener('compositionend', this.validate.bind(this))
+    this.element.addEventListener('submit', this.handleSubmit.bind(this))
+  }
+
+  handleSubmit(event) {
+    this.validate({ target: this.inputTarget })
+    if (this.inputTarget.parentElement.querySelector('.reading-error')) {
+      event.preventDefault()
+      return false
+    }
   }
 
   validate(event) {
     if (event.type === 'input' && event.isComposing) return
     
     const input = event.target
-    const value = input.value
+    let value = input.value
     const validText = value.replace(/[^ぁ-んァ-ンー　 \n]/g, '')
     
     if (value !== validText) {
@@ -20,9 +32,41 @@ export default class extends Controller {
       input.value = validText
       input.setSelectionRange(start, end)
       this.showError('ひらがな・カタカナ以外は入力できません')
-    } else {
-      this.clearError()
+      return
     }
+
+    const spaceCount = (value.match(/[\s　]/g) || []).length
+
+    if (spaceCount === 0) {
+      this.showError('句全体で1つまたは2つの空白を入れてください')
+      return
+    }
+
+    if (value.startsWith(' ') || value.startsWith('　') || value.endsWith(' ') || value.endsWith('　')) {
+      this.showError('句の最初と最後に空白を入れることはできません')
+      return
+    }
+
+    const hasConsecutiveSpaces = /[\s　]{2,}/.test(value)
+    if (hasConsecutiveSpaces) {
+      value = value.replace(/[\s　]+/g, ' ')
+      input.value = value
+      this.showError('連続した空白は入力できません')
+      return
+    } 
+    
+    if (spaceCount > 2) {
+      let newValue = value
+      let matches = value.match(/[\s　]/g) || []
+      for (let i = 2; i < matches.length; i++) {
+        newValue = newValue.replace(/[\s　]/, '')
+      }
+      input.value = newValue
+      this.showError('句全体で1つまたは2つの空白を入れてください')
+      return
+    }
+
+    this.clearError()
   }
 
   handlePaste(event) {
@@ -30,31 +74,31 @@ export default class extends Controller {
     const pastedText = (event.clipboardData || window.clipboardData).getData('text')
     const validText = pastedText.replace(/[^ぁ-んァ-ンー　 \n]/g, '')
     
-    const start = this.element.selectionStart
-    this.element.value = this.element.value.slice(0, start) + validText + this.element.value.slice(this.element.selectionEnd)
+    const start = this.inputTarget.selectionStart
+    this.inputTarget.value = this.inputTarget.value.slice(0, start) + validText + this.inputTarget.value.slice(this.inputTarget.selectionEnd)
     
     const newPosition = start + validText.length
-    this.element.setSelectionRange(newPosition, newPosition)
-    
-    if (pastedText !== validText) {
-      this.showError('ひらがな・カタカナ以外は入力できません')
-    }
+    this.inputTarget.setSelectionRange(newPosition, newPosition)
+  
+    this.validate({ target: this.inputTarget })
   }
 
   showError(message) {
-    let errorDiv = this.element.parentElement.querySelector('.reading-error')
+    let errorDiv = this.inputTarget.parentElement.querySelector('.reading-error')
     if (!errorDiv) {
       errorDiv = document.createElement('div')
       errorDiv.className = 'reading-error alert alert-danger mt-2'
-      this.element.parentElement.appendChild(errorDiv)
+      this.inputTarget.parentElement.querySelector('.reading-error-container').appendChild(errorDiv)
     }
+    this.inputTarget.classList.add('is-invalid')
     errorDiv.textContent = message
   }
 
   clearError() {
-    const errorDiv = this.element.parentElement.querySelector('.reading-error')
+    const errorDiv = this.inputTarget.parentElement.querySelector('.reading-error')
     if (errorDiv) {
       errorDiv.remove()
+      this.inputTarget.classList.remove('is-invalid')
     }
   }
 }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,6 +10,7 @@ class Post < ApplicationRecord
   validate :reading_validation
   validate :content_reading_consistency
   validate :tag_presence_validation
+  validate :validate_reading_spaces
 
   def reading_validation
     return if reading.blank?
@@ -82,6 +83,24 @@ class Post < ApplicationRecord
       errors.add(:base, "俳句か川柳を選択してください")
     elsif tags.count > 1
       errors.add(:base, "俳句か川柳のどちらか一方を選択してください")
+    end
+  end
+
+  def validate_reading_spaces
+    # 全角空白を半角空白に統一
+    normalized_reading = reading.gsub('　', ' ')
+    
+    # 連続した空白のチェック
+    if normalized_reading.match?(/\s{2,}/)
+      errors.add(:reading, "空白は連続して入力できません")
+      return
+    end
+
+    # 空白文字数のカウント
+    space_count = normalized_reading.count(' ')
+    
+    unless (1..2).include?(space_count)
+      errors.add(:reading, "句全体で1つまたは2つの空白を入れてください")
     end
   end
 end

--- a/app/views/posts/new_reading.html.erb
+++ b/app/views/posts/new_reading.html.erb
@@ -9,26 +9,31 @@
           <h3 class="h5 mb-3">入力ルール</h3>
           <ul class="list-unstyled">
             <li>・ひらがな・カタカナのみ使用できます</li>
-            <li>・句切れは空白で入力してください</li>
+            <li>・句全体で1つまたは2つの空白を入れてください</li>
+            <li>・連続した空白は入力できません</li>
           </ul>
         </div>
       </div>
 
       <%= form_with(model: @post, url: new_content_posts_path, method: :get, local: true) do |f| %>
-        <div class="form-group mb-4">
-          <%= f.text_field :reading,
-              class: "form-control",
-              rows: 3,
-              placeholder: "ひらがな・カタカナで入力してください（句切れは空白で入力）",
-              data: { controller: "reading-validation" },
-              required: true %>
-        </div>
+        <div data-controller="reading-validation">
+          <div class="form-group mb-4">
+            <%= f.text_field :reading,
+                class: "form-control",
+                placeholder: "ひらがな・カタカナで入力してください（全体で1～2個の空白）",
+                required: true,
+                data: { 
+                  reading_validation_target: "input"
+                } %>
+            <div class="reading-error-container"></div>
+          </div>
 
-        <%= f.hidden_field :tag_id, value: session.dig(:post_params, 'tag_id') %>
+          <%= f.hidden_field :tag_id, value: session.dig(:post_params, 'tag_id') %>
 
-        <div class="text-center mt-3">
-          <%= f.submit "次へ", class: "button button-primary" %>
-          <%= link_to "戻る", new_type_posts_path, class: "button" %>
+          <div class="text-center mt-3">
+            <%= f.submit "次へ", class: "button button-primary" %>
+            <%= link_to "戻る", new_type_posts_path, class: "button" %>
+          </div>
         </div>
       <% end %>
     </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -40,6 +40,8 @@ ja:
               kana_only_reading: 'ひらがな・カタカナのみ使用できます'
               syllable_blank_reading: '読み方を入力してください'
               syllable_count: "%{count}音以下で入力してください（現在: %{current}音）"
+              invalid_spaces: "句全体で1つまたは2つの空白を入れてください"
+              consecutive_spaces: "空白は連続して入力できません"
             display_content:
               blank: '本文が入力されていません'
             base:


### PR DESCRIPTION
# 読み方の入力制限の実装

## 概要
読み方の入力時における空白文字のバリデーション機能を実装しました。これにより、句の区切りを適切に表現しつつ、入力形式の一貫性を確保できるようになりました。

## 実装内容
### 読み方入力のバリデーション追加
- 空白文字数の制限（1つまたは2つまで）
- 連続した空白の禁止
- 先頭・末尾の空白の禁止
- リアルタイムでのエラーメッセージ表示

### JavaScriptによるバリデーション機能
- Stimulus controllerによる入力チェックの実装
- 入力時のリアルタイムバリデーション
- エラーメッセージの動的表示

### 入力フォームの改善
- エラーメッセージ表示用の領域を追加
- バリデーション結果の視覚的フィードバック

## 変更理由
- 句の区切りを適切に表現するための入力制限
- ユーザーへのリアルタイムなフィードバック提供
- 入力形式の統一による一貫性の向上

## 動作確認項目
1. [x] 空白文字数の制限（1つまたは2つ）
2. [x] ひらがな・カタカナのみ入力可能
3. [x] 連続した空白の入力禁止
4. [x] 先頭・末尾の空白の入力禁止
5. [x] エラーメッセージのリアルタイム表示