### PR TITLE
本文入力時の改行の制限

### DIFF
--- a/app/javascript/controllers/content_validation_controller.js
+++ b/app/javascript/controllers/content_validation_controller.js
@@ -1,0 +1,126 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = [ "input" ];
+
+  connect() {
+    console.log('Content validation controller connected');
+    console.log('Input target:', this.inputTarget);
+    this.inputTarget.addEventListener('input', this.validate.bind(this));
+    this.inputTarget.addEventListener('keydown', this.handleKeydown.bind(this));
+    this.inputTarget.addEventListener('paste', this.handlePaste.bind(this));
+    this.inputTarget.addEventListener('compositionend', this.validate.bind(this));
+    this.element.addEventListener('submit', this.handleSubmit.bind(this));
+  }
+
+  handleSubmit(event) {
+    this.validate({ target: this.inputTarget });
+    if (this.inputTarget.parentElement.querySelector('.content-error')) {
+      event.preventDefault();
+      return false;
+    }
+  }
+
+  handleKeydown(event) {
+    if (event.key === 'Enter') {
+      const newlineCount = (this.inputTarget.value.match(/\n/g) || []).length;
+      if (newlineCount >= 2) {
+        event.preventDefault();
+        this.showError('3つ以上の改行は入力できません');
+      }
+    }
+  }
+
+  validate(event) {
+    if (event.type === 'input' && event.isComposing) return;
+    
+    const input = event.target;
+    const cursor = input.selectionStart;
+    let value = input.value;
+    
+    // 改行の数をカウント
+    const newlineCount = (value.match(/\n/g) || []).length;
+  
+    // 改行が0個の場合
+    if (newlineCount === 0) {
+      this.showError('句全体で1つまたは2つの改行を入れてください');
+      return;
+    }
+  
+    // 先頭・末尾の改行チェック
+    if (value.startsWith('\n') || value.endsWith('\n')) {
+      this.showError('句の最初と最後に改行を入れることはできません');
+      return;
+    }
+  
+    // 連続した改行のチェック
+    const hasConsecutiveNewlines = /\n{2,}/.test(value);
+    if (hasConsecutiveNewlines) {
+      value = value.replace(/\n+/g, '\n');
+      input.value = value;
+      this.showError('連続した改行は入力できません');
+      return;
+    }
+    
+    // 改行が3個以上の場合
+    if (newlineCount > 2) {
+      // 最初の2つの改行を見つける
+      const firstTwoNewlines = [];
+      let pos = -1;
+      for (let i = 0; i < 2; i++) {
+        pos = value.indexOf('\n', pos + 1);
+        if (pos !== -1) {
+          firstTwoNewlines.push(pos);
+        }
+      }
+
+      if (firstTwoNewlines.length === 2) {
+        const beforeThirdNewline = value.substring(0, firstTwoNewlines[1] + 1);
+        const afterThirdNewline = value.substring(firstTwoNewlines[1] + 1).replace(/\n/g, '');
+        value = beforeThirdNewline + afterThirdNewline;
+        input.value = value;
+        
+        // カーソル位置を適切に調整
+        const newCursor = Math.min(cursor, value.length);
+        input.setSelectionRange(newCursor, newCursor);
+      }
+
+      this.showError('3つ以上の改行は入力できません');
+      return;
+    }
+
+    this.clearError();
+  }
+
+  handlePaste(event) {
+    event.preventDefault();
+    const pastedText = (event.clipboardData || window.clipboardData).getData('text');
+    
+    const start = this.inputTarget.selectionStart;
+    this.inputTarget.value = this.inputTarget.value.slice(0, start) + pastedText + this.inputTarget.value.slice(this.inputTarget.selectionEnd);
+    
+    const newPosition = start + pastedText.length;
+    this.inputTarget.setSelectionRange(newPosition, newPosition);
+  
+    this.validate({ target: this.inputTarget });
+  }
+
+  showError(message) {
+    let errorDiv = this.inputTarget.parentElement.querySelector('.content-error');
+    if (!errorDiv) {
+      errorDiv = document.createElement('div');
+      errorDiv.className = 'content-error alert alert-danger mt-2';
+      this.inputTarget.parentElement.querySelector('.content-error-container').appendChild(errorDiv);
+    }
+    this.inputTarget.classList.add('is-invalid');
+    errorDiv.textContent = message;
+  }
+
+  clearError() {
+    const errorDiv = this.inputTarget.parentElement.querySelector('.content-error');
+    if (errorDiv) {
+      errorDiv.remove();
+      this.inputTarget.classList.remove('is-invalid');
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,3 +1,5 @@
 import { application } from "./application"
 import ReadingValidationController from "./reading_validation_controller"
 application.register("reading-validation", ReadingValidationController)
+import ContentValidationController from "./content_validation_controller"
+application.register("content-validation", ContentValidationController)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -11,6 +11,8 @@ class Post < ApplicationRecord
   validate :content_reading_consistency
   validate :tag_presence_validation
   validate :validate_reading_spaces
+  validate :validate_display_content_newlines
+
 
   def reading_validation
     return if reading.blank?
@@ -101,6 +103,30 @@ class Post < ApplicationRecord
     
     unless (1..2).include?(space_count)
       errors.add(:reading, "句全体で1つまたは2つの空白を入れてください")
+    end
+  end
+
+  def validate_display_content_newlines
+    return if display_content.blank?
+  
+    # 改行の数をカウント
+    newline_count = display_content.count("\n")
+  
+    # 改行数のバリデーション（1以上2以下）
+    if newline_count < 1
+      errors.add(:display_content, "句全体で1つまたは2つの改行を入れてください")
+    elsif newline_count > 2
+      errors.add(:display_content, "3つ以上の改行は入力できません")
+    end
+  
+    # 本文の最初と最後に改行がないかチェック
+    if display_content.start_with?("\n") || display_content.end_with?("\n")
+      errors.add(:display_content, "句の最初と最後に改行を入れることはできません")
+    end
+  
+    # 連続した改行がないかチェック
+    if display_content.match?(/\n\n/)
+      errors.add(:display_content, "連続した改行は入力できません")
     end
   end
 end

--- a/app/views/posts/new_content.html.erb
+++ b/app/views/posts/new_content.html.erb
@@ -8,22 +8,38 @@
           <h2 class="h5 mb-3">選択した種類：<%= @tag&.name %></h2>
           <h3 class="h5 mb-3">入力した読み方：</h3>
           <p class="mb-0"><%= @post&.reading %></p>
+
+          <h3 class="h5 mb-3 mt-4">入力ルール</h3>
+          <ul class="list-unstyled">
+            <li>・句全体で1つまたは2つの改行を入れてください</li>
+            <li>・3つ以上の改行は入力できません</li>
+            <li>・連続した改行は入力できません</li>
+            <li>・句の最初と最後に改行を入れることはできません</li>
+          </ul>
         </div>
       </div>
 
       <%= form_with(model: @post, url: confirm_posts_path, method: :get, local: true) do |f| %>
-        <div class="form-group mb-4">
-          <%= f.text_area :display_content,
-              class: "form-control",
-              rows: 3,
-              placeholder: "本文を入力してください" %>
+        <div data-controller="content-validation">
+          <div class="form-group mb-4">
+            <%= f.text_area :display_content,
+                class: "form-control",
+                rows: 3,
+                placeholder: "本文を入力してください（改行1～2回）",
+                required: true,
+                data: { 
+                  content_validation_target: "input"
+                } %>
+            <div class="content-error-container"></div>
+          </div>
+
           <%= f.hidden_field :reading, value: @post&.reading %>
           <%= f.hidden_field :tag_id, value: @tag&.id %>
-        </div>
 
-        <div class="text-center mt-3">
-          <%= f.submit "確認", class: "button button-primary" %>
-          <%= link_to "戻る", new_reading_posts_path, class: "button" %>
+          <div class="text-center mt-3">
+            <%= f.submit "確認", class: "button button-primary" %>
+            <%= link_to "戻る", new_reading_posts_path, class: "button" %>
+          </div>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
# 本文の改行制限の実装

## 概要
本文入力時における改行のバリデーション機能を実装しました。これにより、句の区切りを適切に表現しつつ、入力形式の一貫性を確保できるようになりました。

## 実装内容
### 本文入力のバリデーション追加
- 改行数の制限（1つまたは2つまで）
- 連続した改行の禁止
- 先頭・末尾の改行の禁止
- リアルタイムでのエラーメッセージ表示
- バックエンド側でのバリデーション追加

### JavaScriptによるバリデーション機能
- Stimulus controllerによる入力チェックの実装
- 入力時のリアルタイムバリデーション
- 3つ目以降の改行入力の防止
- ペースト時のバリデーション対応
- カーソル位置の適切な制御

### 入力フォームの改善
- 入力ルールの明確な表示
- エラーメッセージの表示内容を統一
- バリデーション結果の視覚的フィードバック

## 変更理由
- 句の区切りを適切に表現するための入力制限
- ユーザーへのリアルタイムなフィードバック提供
- フロントエンドとバックエンドの両方でのバリデーション実装
- 入力形式の統一による一貫性の向上

## 動作確認項目
1. [x] 改行数の制限（1つまたは2つ）
2. [x] 3つ目以降の改行が入力できないこと
3. [x] 連続した改行の入力禁止
4. [x] 先頭・末尾の改行の入力禁止
5. [x] エラーメッセージのリアルタイム表示
6. [x] ペースト時のバリデーション動作
7. [x] フォーム送信時のバリデーション