### PR TITLE
縦書き・横書きの切り替え

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -101,3 +101,39 @@
     gap: 0.5rem;
   }
 }
+
+.post-content {
+  position: relative;
+  margin: 1rem 0;
+  padding: 1rem;
+  font-family: "游明朝", YuMincho, "ヒラギノ明朝 ProN W3", serif;
+
+  &.vertical-text {
+    writing-mode: vertical-rl;
+    text-orientation: upright;
+    min-height: 200px;
+    height: 400px;
+    margin: 0 auto;
+    padding: 2rem;
+  }
+
+  &.horizontal-text {
+    writing-mode: horizontal-tb;
+    text-orientation: mixed;
+    height: auto;
+    width: 100%;
+    padding: 1rem;
+  }
+}
+
+// カードのリンクスタイルを修正
+.card {
+  a {
+    color: inherit;
+    text-decoration: none;
+    
+    &:hover {
+      text-decoration: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/text_direction.css
+++ b/app/assets/stylesheets/text_direction.css
@@ -1,0 +1,55 @@
+@import 'bootstrap/scss/bootstrap';
+@import 'bootstrap-icons/font/bootstrap-icons';
+
+.post-content {
+  margin: 1rem 0;
+  padding: 1rem;
+  font-family: "游明朝", YuMincho, "ヒラギノ明朝 ProN W3", serif;
+}
+
+.vertical-text {
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  height: 400px;  /* 固定の高さを設定 */
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.horizontal-text {
+  writing-mode: horizontal-tb;
+  text-orientation: mixed;
+  height: auto;
+  width: 100%;
+  padding: 1rem;
+}
+
+.toggle-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  color: #6c757d;
+  background-color: transparent;
+  border: 1px solid #6c757d;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  transition: all 0.15s ease-in-out;
+}
+
+.toggle-button:hover {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d;
+}
+
+.toggle-text {
+  display: inline-block;
+  margin-left: 0.25rem;
+}
+
+@media (max-width: 640px) {
+  .toggle-text {
+    display: none;
+  }
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,4 +1,5 @@
 // Entry point for the build script in your package.json
+import "@hotwired/stimulus"
 import "@hotwired/turbo-rails"
 import "./controllers"
 import * as bootstrap from "bootstrap"

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -3,7 +3,7 @@ import { Application } from "@hotwired/stimulus"
 const application = Application.start()
 
 // Configure Stimulus development experience
-application.debug = false
+application.debug = true
 window.Stimulus   = application
 
 export { application }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,5 +1,8 @@
 import { application } from "./application"
 import ReadingValidationController from "./reading_validation_controller"
-application.register("reading-validation", ReadingValidationController)
 import ContentValidationController from "./content_validation_controller"
+import TextDirectionController from "./text_direction_controller"
+
+application.register("reading-validation", ReadingValidationController)
 application.register("content-validation", ContentValidationController)
+application.register("text-direction", TextDirectionController)

--- a/app/javascript/controllers/text_direction_controller.js
+++ b/app/javascript/controllers/text_direction_controller.js
@@ -5,52 +5,48 @@ export default class extends Controller {
 
   connect() {
     console.log("Text Direction Controller connected")
-    this.initialize()
+    console.log("Content targets:", this.contentTargets.length)
+    this.loadDirection()
   }
 
-  initialize() {
-    this.direction = localStorage.getItem('textDirection') || 'vertical'
-    this.updateDirection()
-    
-    this.observer = new MutationObserver(() => {
+  loadDirection() {
+    try {
+      this.direction = localStorage.getItem('textDirection') || 'vertical'
+      console.log("Loading direction:", this.direction)
       this.updateDirection()
-    })
-    
-    this.observer.observe(document.body, {
-      childList: true,
-      subtree: true
-    })
-  }
-
-  disconnect() {
-    if (this.observer) {
-      this.observer.disconnect()
+    } catch (error) {
+      console.error("Error loading direction:", error)
     }
   }
 
   toggle() {
-    this.direction = this.direction === 'vertical' ? 'horizontal' : 'vertical'
-    localStorage.setItem('textDirection', this.direction)
-    this.updateDirection()
+    try {
+      console.log("Toggle clicked. Current direction:", this.direction)
+      this.direction = this.direction === 'vertical' ? 'horizontal' : 'vertical'
+      localStorage.setItem('textDirection', this.direction)
+      this.updateDirection()
+    } catch (error) {
+      console.error("Error toggling direction:", error)
+    }
   }
 
   updateDirection() {
-    if (!this.hasContentTarget) {
-      return;
-    }
-  
-    this.contentTargets.forEach(element => {
-      // アニメーションのための準備
-      element.style.transition = 'all 0.3s ease-in-out';
+    try {
+      console.log("Updating direction to:", this.direction)
+      console.log("Content targets found:", this.contentTargets.length)
       
-      // クラスの切り替え
-      element.classList.remove('vertical-text', 'horizontal-text');
-      element.classList.add(`${this.direction}-text`);
-    });
-  
-    if (this.hasToggleTarget) {
-      this.toggleTarget.textContent = 
-        this.direction === 'vertical' ? '横書きに切り替え' : '縦書きに切り替え';
+      this.contentTargets.forEach((element, index) => {
+        console.log(`Updating target ${index}:`, element)
+        element.classList.remove('vertical-text', 'horizontal-text')
+        element.classList.add(`${this.direction}-text`)
+      })
+
+      if (this.hasToggleTarget) {
+        this.toggleTarget.textContent = 
+          this.direction === 'vertical' ? '横書きに切り替え' : '縦書きに切り替え'
+      }
+    } catch (error) {
+      console.error("Error in updateDirection:", error)
     }
   }
 }

--- a/app/javascript/controllers/text_direction_controller.js.bak
+++ b/app/javascript/controllers/text_direction_controller.js.bak
@@ -1,0 +1,56 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["content", "toggle"]
+
+  connect() {
+    console.log("Text Direction Controller connected")
+    this.initialize()
+  }
+
+  initialize() {
+    this.direction = localStorage.getItem('textDirection') || 'vertical'
+    this.updateDirection()
+    
+    this.observer = new MutationObserver(() => {
+      this.updateDirection()
+    })
+    
+    this.observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    })
+  }
+
+  disconnect() {
+    if (this.observer) {
+      this.observer.disconnect()
+    }
+  }
+
+  toggle() {
+    this.direction = this.direction === 'vertical' ? 'horizontal' : 'vertical'
+    localStorage.setItem('textDirection', this.direction)
+    this.updateDirection()
+  }
+
+  updateDirection() {
+    if (!this.hasContentTarget) {
+      return;
+    }
+  
+    this.contentTargets.forEach(element => {
+      // アニメーションのための準備
+      element.style.transition = 'all 0.3s ease-in-out';
+      
+      // クラスの切り替え
+      element.classList.remove('vertical-text', 'horizontal-text');
+      element.classList.add(`${this.direction}-text`);
+    });
+  
+    if (this.hasToggleTarget) {
+      this.toggleTarget.textContent = 
+        this.direction === 'vertical' ? '横書きに切り替え' : '縦書きに切り替え';
+    }
+  }
+}

--- a/app/views/posts/_post_content.html.erb
+++ b/app/views/posts/_post_content.html.erb
@@ -1,0 +1,3 @@
+<div class="post-content" data-text-direction-target="content">
+  <%= content %>
+</div>

--- a/app/views/posts/confirm.html.erb
+++ b/app/views/posts/confirm.html.erb
@@ -1,8 +1,16 @@
-<div class="container">
+<div class="container" data-controller="text-direction">
+  <div class="text-end mb-3">
+    <button type="button"
+            data-text-direction-target="toggle"
+            data-action="click->text-direction#toggle"
+            class="btn btn-outline-secondary">
+      縦書き/横書き切り替え
+    </button>
+  </div>
+
   <div class="row justify-content-center">
     <div class="col-md-8">
       <h1 class="text-center mb-4">投稿内容の確認</h1>
-
       <div class="card mb-4">
         <div class="card-body">
           <div class="mb-4">
@@ -17,7 +25,7 @@
 
           <div class="mb-4">
             <h2 class="h5 mb-2">本文</h2>
-            <p class="mb-0 post-content"><%= @post&.display_content %></p>
+            <%= render partial: 'post_content', locals: { content: @post&.display_content } %>
           </div>
         </div>
       </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,19 +1,28 @@
-<div class="container">
+<div class="container" data-controller="text-direction">
+  <div class="text-end mb-3">
+    <button type="button"
+            data-text-direction-target="toggle"
+            data-action="click->text-direction#toggle"
+            class="btn btn-outline-secondary">
+      縦書き/横書き切り替え
+    </button>
+  </div>
+
   <div class="row justify-content-center">
     <div class="col-md-8">
       <h1 class="text-center mb-4">句一覧</h1>
       <% @posts.each do |post| %>
-        <%= link_to post_path(post), class: "text-decoration-none" do %>
-          <div class="card mb-3">
+        <div class="card mb-3">
+          <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
             <div class="card-body">
               <div class="d-flex justify-content-between align-items-start mb-2">
                 <span class="badge bg-primary"><%= post.tags.first&.name %></span>
                 <small class="text-muted"><%= l post.created_at, format: :long %></small>
               </div>
-              <p class="card-text post-content"><%= post.display_content %></p>
+              <%= render partial: 'post_content', locals: { content: post.display_content } %>
             </div>
-          </div>
-        <% end %>
+          <% end %>
+        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,9 +1,18 @@
-<div class="container">
+<div class="container" data-controller="text-direction">
+  <div class="text-end mb-3">
+    <button type="button"
+            data-text-direction-target="toggle"
+            data-action="click->text-direction#toggle"
+            class="btn btn-outline-secondary">
+      縦書き/横書き切り替え
+    </button>
+  </div>
+
   <div class="row justify-content-center">
     <div class="col-md-8">
       <div class="card mb-3">
         <div class="card-body">
-          <p class="card-text post-content"><%= @post.display_content %></p>
+          <%= render partial: 'post_content', locals: { content: @post.display_content } %>
           <p class="card-text text-muted"><small>読み：<%= @post.reading %></small></p>
           <small class="text-muted"><%= l @post.created_at, format: :long %></small>
           

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,4 +1,13 @@
-<div class="container">
+<div class="container" data-controller="text-direction">
+  <div class="text-end mb-3">
+    <button type="button"
+            data-text-direction-target="toggle"
+            data-action="click->text-direction#toggle"
+            class="btn btn-outline-secondary">
+      縦書き/横書き切り替え
+    </button>
+  </div>
+
   <div class="row justify-content-center">
     <div class="col-md-8">
       <h1 class="text-center mb-4">マイページ</h1>
@@ -28,18 +37,18 @@
 
       <h2 class="text-center mb-4">投稿した句一覧</h2>
       <% @posts.each do |post| %>
-        <%= link_to post_path(post), class: "text-decoration-none" do %>
-          <div class="card mb-3">
+        <div class="card mb-3">
+          <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
             <div class="card-body">
               <div class="d-flex justify-content-between align-items-start mb-2">
                 <span class="badge bg-primary"><%= post.tags.first&.name %></span>
                 <small class="text-muted"><%= l post.created_at, format: :long %></small>
               </div>
-              <p class="card-text post-content"><%= post.display_content %></p>
+              <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
             </div>
-          </div>
-        <% end %>
-      <% end %>
+          <% end %>
+        </div>
+      <% end %>      
 
       <div class="card mt-4">
         <div class="card-body text-center">


### PR DESCRIPTION
# 句の表示切り替え機能の実装

## 概要
句の表示方向（縦書き・横書き）を切り替える機能を実装しました。これにより、ユーザーが好みの表示方法を選択できるようになり、句をより適切な形式で閲覧できるようになりました。

## 実装内容
### 表示切り替え機能の基本実装
- Stimulusコントローラーによる表示方向の制御
- LocalStorageを使用した表示設定の永続化
- 各ページでの統一的な表示制御

### CSSによる表示制御
- 縦書き・横書きのスタイル定義
- 和文フォントの適用
- レスポンシブ対応の実装

### 切り替えUIの実装
- ページ上部に切り替えボタンを配置
- 直感的な操作性の実現
- 現在の表示状態の視覚的フィードバック

## 変更理由
- 日本語の句に適した表示方法の提供
- ユーザー体験の向上
- 縦書き表示による視認性の改善

## 動作確認項目
1. [x] 縦書き・横書きの切り替え動作
2. [x] 設定の永続化（ページ遷移後も維持）
3. [x] 一覧画面での表示切り替え
4. [x] 詳細画面での表示切り替え
5. [x] プロフィール画面での表示切り替え
6. [x] 投稿確認画面での表示切り替え