### PR TITLE
お題の実装

### DIFF
--- a/app/controllers/image_posts_controller.rb
+++ b/app/controllers/image_posts_controller.rb
@@ -11,23 +11,56 @@ class ImagePostsController < ApplicationController
 
   def create
     if params[:image_post].nil?
-      # 画像なしの場合は直接new_type_posts_pathへリダイレクト
       redirect_to new_type_posts_path
       return
     end
-
+  
     @image_post = ImagePost.new(image_post_params)
-
+  
     if @image_post.save
+      # ここでお題を作成
+      theme = current_user.themes.build(
+        description: @image_post.description,
+        image_post: @image_post
+      )
+  
+      if @image_post.image.attached?
+        theme.image.attach(@image_post.image.blob)
+      end
+  
+      theme.save
+  
       session[:image_post_id] = @image_post.id
-      session.delete(:temp_image_post) # 一時保存データを削除
+      session.delete(:temp_image_post)
       redirect_to new_type_posts_path
     else
-      # エラーの場合、入力データを一時保存
       session[:temp_image_post] = image_post_params.to_h
       flash.now[:alert] = '画像の投稿に失敗しました'
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def complete
+    @image_post = ImagePost.find(session[:image_post_id])
+
+    if current_user
+      theme = current_user.themes.build(
+        description: @image_post.description,
+        image_post: @image_post
+      )
+  
+      if @image_post.image.attached?
+        theme.image.attach(@image_post.image.blob)
+      end
+      
+      if theme.save
+        flash[:notice] = 'お題が作成されました'
+      else
+        flash[:alert] = 'お題の作成に失敗しました'
+      end
+    end
+    
+    session.delete(:image_post_id)
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,10 +3,11 @@ class PostsController < ApplicationController
   before_action :set_post, only: [:show, :destroy]
   before_action :ensure_correct_user, only: [:destroy]
   before_action :load_post_from_session, only: [:new_reading, :new_content, :confirm]
+  before_action :set_theme, only: [:new_type, :new_reading, :new_content, :confirm]
 
   def index
     begin
-      @posts = Post.includes(:user, :tags, :image_post).order(created_at: :desc)
+      @posts = Post.includes(:user, :tags, :image_post, :theme).order(created_at: :desc)
       @image_post = ImagePost.find_by(id: session[:image_post_id]) if session[:image_post_id]
     rescue => e
       logger.error "Error in posts#index: #{e.message}"
@@ -17,8 +18,12 @@ class PostsController < ApplicationController
 
   def show
     begin
-      @post = Post.includes(:image_post, :tags).find(params[:id])
-      @image_post = @post.image_post
+      @post = Post.includes(:image_post, :tags, :theme).find(params[:id])
+      @theme = if @post.theme.present?
+        @post.theme
+      elsif @post.image_post.present?
+        Theme.find_by(image_post_id: @post.image_post.id)
+      end
     rescue ActiveRecord::RecordNotFound
       redirect_to posts_path, alert: '投稿が見つかりませんでした'
     rescue => e
@@ -30,7 +35,15 @@ class PostsController < ApplicationController
   def new_type
     begin
       @post = Post.new
-      @image_post = ImagePost.find_by(id: session[:image_post_id]) if session[:image_post_id]
+      if @theme
+        unless @theme.available_for?(current_user)
+          redirect_to theme_path(@theme), alert: 'このお題では句を詠むことができません'
+          return
+        end
+        session[:theme_id] = @theme.id
+      else
+        @image_post = ImagePost.find_by(id: session[:image_post_id]) if session[:image_post_id]
+      end
       ensure_tags_exist
     rescue => e
       logger.error "Error in posts#new_type: #{e.message}"
@@ -81,28 +94,34 @@ class PostsController < ApplicationController
 
   def create
     begin
-      @image_post = ImagePost.find_by(id: session[:image_post_id]) if session[:image_post_id]
       @post = current_user.posts.build(
         reading: session[:post_params]['reading'],
         display_content: session[:post_params]['display_content']
       )
-
-      @post.image_post_id = session[:image_post_id] if session[:image_post_id]
-    
+  
+      if session[:theme_id]
+        @post.theme_id = session[:theme_id]
+        theme_tag = Tag.find_or_create_by!(name: 'お題から詠まれた句')
+        @post.tags << theme_tag
+      else
+        @post.image_post_id = session[:image_post_id] if session[:image_post_id]
+      end
+      
       tag_id = session[:post_params]['tag_id'] || session[:post_params][:tag_id]
       if tag_id.present?
         tag = Tag.find_by(id: tag_id)
         @post.tags << tag if tag
       end
-    
+      
       if @post.save
         session[:post_params] = nil
         session.delete(:image_post_id)
+        session.delete(:theme_id)
         redirect_to posts_path, notice: '投稿が完了しました'
       else
         errors = @post.errors.full_messages
         flash[:alert] = errors.join("<br>").html_safe
-
+  
         if @post.tags.empty?
           redirect_to new_type_posts_path
         elsif @post.reading.blank?
@@ -141,12 +160,26 @@ class PostsController < ApplicationController
 
   def destroy
     begin
-      @post.destroy!
-      redirect_to posts_path, status: :see_other, notice: '投稿を削除しました'
+      ActiveRecord::Base.transaction do
+        if @post.image_post.present?
+          theme = Theme.find_by(image_post_id: @post.image_post.id)
+          theme.destroy! if theme
+  
+          remaining_posts = Post.where(image_post_id: @post.image_post.id)
+                              .where.not(id: @post.id)
+                              .exists?
+          @post.image_post.destroy! unless remaining_posts
+        end
+        
+        @post.destroy!
+        flash[:notice] = '投稿を削除しました'
+      end
     rescue => e
-      logger.error "Error in posts#destroy: #{e.message}"
-      redirect_to posts_path, alert: '削除中にエラーが発生しました'
+      logger.error "Post destroy error: #{e.class}: #{e.message}"
+      logger.error e.backtrace.join("\n")
+      flash[:alert] = '削除中にエラーが発生しました'
     end
+    redirect_to posts_path
   end
 
   private
@@ -156,9 +189,25 @@ class PostsController < ApplicationController
   end
 
   def set_post
-    @post = Post.includes(:image_post, :tags).find(params[:id])
+    @post = Post.includes(:user, 
+                         :post_tags, 
+                         :tags, 
+                         :theme, 
+                         :image_post)
+                .find(params[:id])
   rescue ActiveRecord::RecordNotFound
     redirect_to posts_path, alert: '投稿が見つかりませんでした'
+  end
+
+  def set_theme
+    if params[:theme_id]
+      @theme = Theme.find(params[:theme_id])
+    elsif session[:theme_id]
+      @theme = Theme.find(session[:theme_id])
+    end
+  rescue ActiveRecord::RecordNotFound
+    session.delete(:theme_id)
+    redirect_to themes_path, alert: 'お題が見つかりませんでした'
   end
 
   def ensure_correct_user
@@ -180,6 +229,6 @@ class PostsController < ApplicationController
       Tag.find_or_create_by!(name: '俳句')
       Tag.find_or_create_by!(name: '川柳')
     end
-    @tags = Tag.all
+    @tags = Tag.where(name: ['俳句', '川柳'])
   end
 end

--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -1,0 +1,68 @@
+class ThemesController < ApplicationController
+  before_action :require_login
+  before_action :set_theme, only: [:show, :write]
+
+  def index
+    @themes = Theme.all.order(created_at: :desc)
+  end
+
+  def show
+    @posts = @theme.posts.includes(:user, :tags).order(created_at: :desc)
+  end
+
+  def new
+    @theme = Theme.new
+  end
+
+  def create
+    @theme = current_user.themes.build(theme_params)
+    if @theme.save
+      redirect_to @theme, notice: 'お題を作成しました'
+    else
+      render :new
+    end
+  end
+
+  def write
+    return redirect_to login_path, alert: 'ログインが必要です' unless current_user
+    session[:theme_id] = @theme.id
+    redirect_to new_type_theme_posts_path(@theme)
+  end
+
+  def destroy
+    begin
+      ActiveRecord::Base.transaction do
+        @theme = Theme.find(params[:id])
+
+        unless @theme.user == current_user
+          redirect_to @theme, alert: '削除権限がありません'
+          return
+        end
+
+        if @theme.destroy
+          flash[:notice] = 'お題を削除しました'
+          redirect_to themes_path
+        else
+          flash[:alert] = '削除できませんでした'
+          redirect_to @theme
+        end
+      end
+    rescue => e
+      logger.error "Theme destroy error: #{e.message}"
+      logger.error e.backtrace.join("\n")
+      redirect_to @theme, alert: '削除中にエラーが発生しました'
+    end
+  end
+
+  private
+
+  def set_theme
+    @theme = Theme.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to themes_path, alert: 'お題が見つかりませんでした'
+  end
+
+  def theme_params
+    params.require(:theme).permit(:description, :image)
+  end
+end

--- a/app/helpers/themes_helper.rb
+++ b/app/helpers/themes_helper.rb
@@ -1,0 +1,2 @@
+module ThemesHelper
+end

--- a/app/models/image_post.rb
+++ b/app/models/image_post.rb
@@ -1,5 +1,6 @@
 class ImagePost < ApplicationRecord
   has_one_attached :image
+  has_one :theme
   has_many :posts, dependent: :nullify
   validates :description, length: { maximum: 10 }
   

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,5 @@
 class Post < ApplicationRecord
+  belongs_to :theme, optional: true
   attr_accessor :tag_id
   belongs_to :user
   belongs_to :image_post, optional: true

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,0 +1,19 @@
+class Theme < ApplicationRecord
+  belongs_to :user
+  belongs_to :image_post, optional: true, dependent: :destroy
+  has_many :posts
+  has_one_attached :image
+
+  validates :description, presence: true
+
+  def posted_by?(user)
+    posts.exists?(user_id: user.id)
+  end
+
+  def available_for?(user)
+    return false if user.nil?
+    return false if user.id == self.user_id
+    return false if posted_by?(user)
+    true
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :posts
+  has_many :themes
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -17,6 +17,7 @@
     <% else %>
       <div class="space-y-4">
         <%= link_to '句一覧を見る', posts_path, class: 'button button-info' %>
+        <%= link_to 'お題一覧', themes_path, class: 'button button-info' %>
         <div>
           <%= link_to '句を詠む', new_image_post_path, class: 'button button-success' %>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
           <%= link_to 'ホーム', root_path, class: 'button' %>
           <% if logged_in? %>
             <%= link_to '句一覧', posts_path, class: 'button' %>
+            <%= link_to 'お題一覧', themes_path, class: 'button' %>
           <% end %>
         </div>
 

--- a/app/views/posts/confirm.html.erb
+++ b/app/views/posts/confirm.html.erb
@@ -3,7 +3,14 @@
     <div class="col-md-8">
       <h1 class="text-center mb-4">投稿内容の確認</h1>
 
-      <% if @image_post&.image.present? %>
+      <% if @theme %>
+        <div class="card mb-4">
+          <div class="card-body">
+            <%= image_tag @theme.image, class: "w-100 rounded-lg" if @theme.image.attached? %>
+            <p class="mt-2 text-muted"><%= @theme.description %></p>
+          </div>
+        </div>
+      <% elsif @image_post&.image.present? %>
         <div class="card mb-4">
           <div class="card-body">
             <h2 class="h5 mb-3">選択した画像</h2>
@@ -43,7 +50,11 @@
         <%= link_to "本文を修正", new_content_posts_path, class: "button me-2" %>
         <%= link_to "読み方を修正", new_reading_posts_path, class: "button me-2" %>
         <%= link_to "種類を修正", new_type_posts_path, class: "button me-2" %>
-        <%= link_to "画像を修正", new_image_post_path, class: "button" %>
+        <% if @theme %>
+          <%= link_to "お題の選択に戻る", themes_path, class: "button" %>
+        <% else %>
+          <%= link_to "画像を修正", new_image_post_path, class: "button" %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -15,7 +15,12 @@
         <div class="card mb-3">
           <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
             <div class="card-body">
-              <% if post.image_post&.image.present? %>
+              <% if post.theme.present? %>
+                <div class="mb-4">
+                  <%= image_tag post.theme.image, class: "w-100 rounded-lg" if post.theme.image.attached? %>
+                  <p class="mt-2 text-muted"><%= post.theme.description %></p>
+                </div>
+              <% elsif post.image_post&.image.present? %>
                 <div class="mb-4">
                   <%= image_tag url_for(post.image_post.image), class: "w-100 rounded-lg" %>
                   <% if post.image_post.description.present? %>
@@ -23,8 +28,13 @@
                   <% end %>
                 </div>
               <% end %>
+              
               <div class="d-flex justify-content-between align-items-start mb-2">
-                <span class="badge bg-primary"><%= post.tags.first&.name %></span>
+                <div class="tags">
+                  <% post.tags.each do |tag| %>
+                    <span class="badge bg-primary me-1"><%= tag.name %></span>
+                  <% end %>
+                </div>
                 <small class="text-muted"><%= l post.created_at, format: :long %></small>
               </div>
               <%= render partial: 'post_content', locals: { content: post.display_content } %>

--- a/app/views/posts/new_content.html.erb
+++ b/app/views/posts/new_content.html.erb
@@ -1,7 +1,14 @@
 <div class="container">
   <div class="row justify-content-center">
     <div class="col-md-8">
-      <% if @image_post&.image.present? %>
+      <% if @theme %>
+        <div class="card mb-4">
+          <div class="card-body">
+            <%= image_tag @theme.image, class: "w-100 rounded-lg" if @theme.image.attached? %>
+            <p class="mt-2 text-muted"><%= @theme.description %></p>
+          </div>
+        </div>
+      <% elsif @image_post&.image.present? %>
         <div class="card mb-4">
           <div class="card-body">
             <h2 class="h5 mb-3">選択した画像</h2>

--- a/app/views/posts/new_reading.html.erb
+++ b/app/views/posts/new_reading.html.erb
@@ -1,7 +1,14 @@
 <div class="container">
   <div class="row justify-content-center">
     <div class="col-md-8">
-      <% if @image_post&.image.present? %>
+      <% if @theme %>
+        <div class="card mb-4">
+          <div class="card-body">
+            <%= image_tag @theme.image, class: "w-100 rounded-lg" if @theme.image.attached? %>
+            <p class="mt-2 text-muted"><%= @theme.description %></p>
+          </div>
+        </div>
+      <% elsif @image_post&.image.present? %>
         <div class="card mb-4">
           <div class="card-body">
             <h2 class="h5 mb-3">選択した画像</h2>

--- a/app/views/posts/new_type.html.erb
+++ b/app/views/posts/new_type.html.erb
@@ -1,7 +1,14 @@
 <div class="container mx-auto px-4 py-8">
   <div class="row justify-content-center">
     <div class="col-md-8">
-      <% if @image_post&.image.present? %>
+      <% if @theme %>
+        <div class="card mb-4">
+          <div class="card-body">
+            <%= image_tag @theme.image, class: "w-100 rounded-lg" if @theme.image.attached? %>
+            <p class="mt-2 text-muted"><%= @theme.description %></p>
+          </div>
+        </div>
+      <% elsif @image_post&.image.present? %>
         <div class="card mb-4">
           <div class="card-body">
             <h2 class="h5 mb-3">選択した画像</h2>
@@ -30,7 +37,11 @@
 
         <div class="text-center mt-3">
           <%= f.submit "次へ", class: "button button-primary" %>
-          <%= link_to "戻る", new_image_post_path, class: "button" %>
+          <% if @theme %>
+            <%= link_to "戻る", theme_path(@theme), class: "button" %>
+          <% else %>
+            <%= link_to "戻る", new_image_post_path, class: "button" %>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -12,27 +12,51 @@
     <div class="col-md-8">
       <div class="card mb-3">
         <div class="card-body">
-          <% if @post.image_post&.image.present? %>
+          <% if @post.theme.present? || @theme.present? %>
             <div class="mb-4">
-              <%= image_tag url_for(@post.image_post.image), class: "w-100 rounded-lg" %>
+              <% theme = @post.theme || @theme %>
+              <%= image_tag theme.image, class: "w-100 rounded-lg" if theme.image.attached? %>
+              <p class="mt-2 text-muted"><%= theme.description %></p>
+              <% if logged_in? && theme.available_for?(current_user) %>
+                <%= link_to 'このお題で詠む', new_type_theme_posts_path(theme), 
+                  class: "button button-primary mt-2 d-block text-center" %>
+              <% end %>
+            </div>
+          <% elsif @post.image_post.present? %>
+            <div class="mb-4">
+              <% if @post.image_post.image.attached? %>
+                <%= image_tag url_for(@post.image_post.image), class: "w-100 rounded-lg" %>
+              <% end %>
               <% if @post.image_post.description.present? %>
                 <p class="mt-2 text-muted"><%= @post.image_post.description %></p>
               <% end %>
             </div>
           <% end %>
+
           <%= render partial: 'post_content', locals: { content: @post.display_content } %>
           <p class="card-text text-muted"><small>読み：<%= @post.reading %></small></p>
-          <small class="text-muted"><%= l @post.created_at, format: :long %></small>
+
+          <div class="post-tags mt-2">
+            <% @post.tags.each do |tag| %>
+              <span class="badge bg-secondary"><%= tag.name %></span>
+            <% end %>
+          </div>
+          
+          <small class="text-muted d-block mt-2"><%= l @post.created_at, format: :long %></small>
           
           <% if logged_in? && current_user == @post.user %>
             <div class="mt-3">
               <%= button_to '削除', post_path(@post), 
                   method: :delete, 
                   data: { turbo_confirm: "この句を削除してもよろしいですか？" },
-                  class: 'button button-danger' %>
+                  class: 'button button-danger w-100' %>
             </div>
           <% end %>
         </div>
+      </div>
+
+      <div class="mt-3 text-center">
+        <%= link_to '戻る', posts_path, class: "text-blue-500 hover:text-blue-700" %>
       </div>
     </div>
   </div>

--- a/app/views/themes/index.html.erb
+++ b/app/views/themes/index.html.erb
@@ -1,0 +1,27 @@
+<div class="container mx-auto px-4 py-8">
+  <h1 class="text-2xl font-bold mb-6">お題一覧</h1>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <% @themes.each do |theme| %>
+      <%= link_to theme_path(theme), class: "block" do %>
+        <div class="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-300">
+          <% if theme.image.attached? %>
+            <%= image_tag theme.image, class: "w-full h-48 object-cover" %>
+          <% end %>
+          <div class="p-4">
+            <p class="text-gray-700"><%= theme.description %></p>
+            <div class="mt-4 text-sm text-gray-500">
+              <span><%= theme.created_at.strftime("%Y年%m月%d日") %></span>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+
+  <% if logged_in? %>
+    <div class="mt-8">
+      <%= link_to '新しいお題を作成', new_theme_path, class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/themes/new.html.erb
+++ b/app/views/themes/new.html.erb
@@ -1,0 +1,30 @@
+<div class="container mx-auto px-4 py-8">
+  <h1 class="text-2xl font-bold mb-6">新しいお題を作成</h1>
+
+  <%= form_with(model: @theme, local: true, class: "max-w-2xl") do |f| %>
+    <% if @theme.errors.any? %>
+      <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+        <ul class="list-disc list-inside">
+          <% @theme.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="mb-6">
+      <%= f.label :image, '画像', class: "block text-gray-700 text-sm font-bold mb-2" %>
+      <%= f.file_field :image, class: "w-full" %>
+    </div>
+
+    <div class="mb-6">
+      <%= f.label :description, 'お題の説明', class: "block text-gray-700 text-sm font-bold mb-2" %>
+      <%= f.text_area :description, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", rows: 4 %>
+    </div>
+
+    <div class="flex items-center justify-between">
+      <%= f.submit '作成する', class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
+      <%= link_to '戻る', themes_path, class: "text-blue-500 hover:text-blue-700" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -1,0 +1,63 @@
+<div class="container" data-controller="text-direction">
+  <div class="text-end mb-3">
+    <button type="button"
+            data-text-direction-target="toggle"
+            data-action="click->text-direction#toggle"
+            class="btn btn-outline-secondary">
+      縦書き/横書き切り替え
+    </button>
+  </div>
+
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <div class="card mb-3">
+        <div class="card-body">
+          <% if @theme.image.attached? %>
+            <%= image_tag @theme.image, class: "w-100 rounded-lg" %>
+          <% end %>
+          
+          <p class="mt-2 text-muted"><%= @theme.description %></p>
+          
+          <% if logged_in? && @theme.available_for?(current_user) %>
+            <%= link_to 'このお題で詠む', new_type_theme_posts_path(@theme), 
+                class: "button button-primary mt-2 d-block text-center" %>
+          <% elsif logged_in? && @theme.posted_by?(current_user) %>
+            <div class="alert alert-info mt-2">
+              このお題では既に句を詠んでいます
+            </div>
+          <% end %>
+
+          <% if logged_in? && current_user == @theme.user %>
+            <div class="mt-2">
+              <%= button_to '削除', theme_path(@theme), 
+                  method: :delete,
+                  data: { turbo_confirm: "このお題を削除してもよろしいですか？\n（このお題で詠まれた句は削除されません）" },
+                  class: 'button button-danger' %>
+            </div>
+          <% end %>
+
+          <div class="mt-8">
+            <h2 class="text-xl font-bold mb-4">このお題で詠まれた句</h2>
+            <div class="grid gap-4">
+              <% @posts.each do |post| %>
+                <%= link_to post_path(post), class: "block" do %>
+                  <div class="bg-gray-50 p-4 rounded-lg hover:bg-gray-100 transition-colors duration-200">
+                    <p class="text-gray-600 mb-2"><%= post.reading %></p>
+                    <p class="text-gray-800 mb-2"><%= post.display_content %></p>
+                    <div class="text-sm text-gray-500">
+                      <span><%= post.created_at.strftime("%Y年%m月%d日") %></span>
+                    </div>
+                  </div>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-6">
+        <%= link_to '戻る', themes_path, class: "text-blue-500 hover:text-blue-700" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :cloudinary
+  #config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,20 @@ Rails.application.routes.draw do
       get :complete
     end
   end
+
+  resources :themes do
+    resources :posts do
+      collection do
+        get :new_type
+        get :new_reading
+        get :new_content
+        get :confirm
+      end
+    end
+    member do
+      get :write
+    end
+  end
   
   resource :profile, only: [:show, :edit, :update] do
     get 'password', to: 'profiles#edit_password'

--- a/db/migrate/20250114150600_create_themes.rb
+++ b/db/migrate/20250114150600_create_themes.rb
@@ -1,0 +1,11 @@
+class CreateThemes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :themes do |t|
+      t.string :title
+      t.text :description
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250114150819_add_theme_ref_to_posts.rb
+++ b/db/migrate/20250114150819_add_theme_ref_to_posts.rb
@@ -1,0 +1,5 @@
+class AddThemeRefToPosts < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :posts, :theme, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20250114164547_add_image_post_ref_to_themes.rb
+++ b/db/migrate/20250114164547_add_image_post_ref_to_themes.rb
@@ -1,0 +1,5 @@
+class AddImagePostRefToThemes < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :themes, :image_post, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20250115001521_change_image_post_id_nullable_in_themes.rb
+++ b/db/migrate/20250115001521_change_image_post_id_nullable_in_themes.rb
@@ -1,0 +1,5 @@
+class ChangeImagePostIdNullableInThemes < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :themes, :image_post_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_14_001825) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_15_001521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -65,7 +65,9 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_14_001825) do
     t.datetime "updated_at", null: false
     t.string "reading", default: "", null: false
     t.bigint "image_post_id"
+    t.bigint "theme_id"
     t.index ["image_post_id"], name: "index_posts_on_image_post_id"
+    t.index ["theme_id"], name: "index_posts_on_theme_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
@@ -74,6 +76,17 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_14_001825) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
+  create_table "themes", force: :cascade do |t|
+    t.string "title"
+    t.text "description"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "image_post_id"
+    t.index ["image_post_id"], name: "index_themes_on_image_post_id"
+    t.index ["user_id"], name: "index_themes_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -93,5 +106,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_14_001825) do
   add_foreign_key "post_tags", "posts"
   add_foreign_key "post_tags", "tags"
   add_foreign_key "posts", "image_posts"
+  add_foreign_key "posts", "themes"
   add_foreign_key "posts", "users"
+  add_foreign_key "themes", "image_posts"
+  add_foreign_key "themes", "users"
 end

--- a/test/controllers/themes_controller_test.rb
+++ b/test/controllers/themes_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class ThemesControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get themes_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get themes_show_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get themes_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get themes_create_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/themes.yml
+++ b/test/fixtures/themes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  description: MyText
+  user: one
+
+two:
+  title: MyString
+  description: MyText
+  user: two

--- a/test/models/theme_test.rb
+++ b/test/models/theme_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ThemeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# お題・句関連機能の実装と改善

## 概要
お題の投稿、お題からの句作成機能、関連する制限機能を実装しました。また、既存の句の表示に関する改善も行いました。
これにより、ユーザー間でお題を共有し、それに基づいた句の創作活動が可能になりました。

## 実装内容
### お題の基本機能
- お題の投稿・閲覧機能
- お題の削除機能（作成者のみ可能）
- お題と画像投稿の関連付け

### お題からの句作成機能
- お題から句を詠む機能の実装
- 自動的な「お題から詠まれた句」タグの付与
- 投稿フローの統一（画像投稿と同じフロー）

### 投稿制限機能
- 自分が作成したお題では句を詠めない制限
- 一つのお題につき一人一句の制限
- お題から詠まれた句タグの選択不可

### UI/UX の改善
- 句一覧での「お題」ラベルの削除
- 適切な場所での「このお題で詠む」リンクの表示
- 句の削除時の関連データの適切な処理

## 動作確認項目
1. [x] お題の投稿・削除機能
   - お題の作成と保存
   - 作成者による削除
   - 関連データの適切な処理
2. [x] お題からの句作成機能
   - お題詳細画面からの投稿
   - 句の詳細画面からの投稿
   - 自動タグ付与の確認
3. [x] 投稿制限の動作
   - 自作お題での投稿制限
   - 一人一句の制限
   - 適切なメッセージ表示
4. [x] データの整合性
   - 句の削除時の関連データ処理
   - お題の削除時の関連データ処理
5. [x] UI/UXの改善
   - 適切なリンク表示
   - 不要なラベルの削除
   - エラーメッセージの表示

## 技術的変更点
- `Theme`モデルに投稿制限のためのメソッド追加
- `PostsController`の投稿フロー修正
- お題関連のビューテンプレート作成
- 既存ビューの改善

## 補足
- 将来的な句・お題の削除機能は管理者による承認制に移行予定
- 一つのお題につき一人一句の制限は、創作の質を保つため設定