### PR TITLE
Active Storageの環境別設定の修正

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,8 +34,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :cloudinary
-  #config.active_storage.service = :local
+  config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
# Active Storageの環境別設定の修正

## 概要
画像アップロード機能において、開発環境と本番環境でのストレージサービスの設定を適切に分離しました。
これにより、開発時はローカルストレージを使用し、本番環境ではCloudinaryを使用する構成に修正しました。

## 実装内容
### 開発環境の設定
- Active Storageのサービスを`:local`に設定
- 画像のバリアント処理にMiniMagickを使用
- ローカルでの開発効率を考慮した設定を維持

### 本番環境の設定
- Active Storageのサービスを`:cloudinary`に設定
- Cloudinaryとの連携による安定した画像ホスティングの実現
- 本番環境に適した設定の最適化

## 動作確認項目
1. [x] 開発環境での画像アップロード
   - ローカルストレージへの保存
   - 画像の表示
   - バリアント生成
2. [x] 本番環境での画像アップロード
   - Cloudinaryへの保存
   - 画像の表示
   - バリアント生成

## 技術的変更点
- 環境別の設定ファイルの調整
  - development.rb: `:local`ストレージの設定
  - production.rb: `:cloudinary`の設定

## 補足
- 開発環境と本番環境で異なるストレージサービスを使用することで、開発効率と本番環境での安定性を両立
- 環境変数（Cloudinary認証情報）は既存の設定を維持