### PR TITLE
自分の投稿にタグ

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -17,7 +17,7 @@
     <% else %>
       <div class="space-y-4">
         <%= link_to '句一覧を見る', posts_path, class: 'button button-info' %>
-        <%= link_to 'お題一覧', themes_path, class: 'button button-info' %>
+        <%= link_to 'お題一覧を見る', themes_path, class: 'button button-info' %>
         <div>
           <%= link_to '句を詠む', new_image_post_path, class: 'button button-success' %>
         </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -9,6 +9,9 @@
           <% post.tags.each do |tag| %>
             <span class="badge bg-primary me-1"><%= tag.name %></span>
           <% end %>
+          <% if logged_in? && current_user == post.user %>
+            <span class="badge bg-success me-1">自分が詠んだ句</span>
+          <% end %>
         </div>
         <small class="text-muted"><%= l post.created_at, format: :long %></small>
       </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -41,6 +41,9 @@
                     <% post.tags.each do |tag| %>
                       <span class="badge bg-primary me-1"><%= tag.name %></span>
                     <% end %>
+                    <% if logged_in? && current_user == post.user %>
+                      <span class="badge bg-success me-1">自分が詠んだ句</span>
+                    <% end %>
                   </div>
                   <small class="text-muted"><%= l post.created_at, format: :long %></small>
                 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -40,6 +40,9 @@
             <% @post.tags.each do |tag| %>
               <span class="badge bg-secondary"><%= tag.name %></span>
             <% end %>
+            <% if logged_in? && current_user == @post.user %>
+              <span class="badge bg-success">自分が詠んだ句</span>
+            <% end %>
           </div>
           
           <small class="text-muted d-block mt-2"><%= l @post.created_at, format: :long %></small>

--- a/app/views/themes/index.html.erb
+++ b/app/views/themes/index.html.erb
@@ -15,6 +15,9 @@
               
               <div class="mt-2">
                 <p class="text-muted"><%= theme.description %></p>
+                <% if logged_in? && current_user == theme.user %>
+                  <span class="badge bg-info">自分が投稿したお題</span>
+                <% end %>
               </div>
 
               <div class="d-flex justify-content-between align-items-start mt-2">

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -16,7 +16,12 @@
             <%= image_tag @theme.image, class: "w-100 rounded-lg" %>
           <% end %>
           
-          <p class="mt-2 text-muted"><%= @theme.description %></p>
+          <div class="mt-2">
+            <p class="text-muted"><%= @theme.description %></p>
+            <% if logged_in? && current_user == @theme.user %>
+              <span class="badge bg-info">自分が投稿したお題</span>
+            <% end %>
+          </div>
           
           <% if logged_in? && @theme.available_for?(current_user) %>
             <%= link_to 'このお題で詠む', new_type_theme_posts_path(@theme), 


### PR DESCRIPTION
# 自作の句・お題の視認性向上

## 概要
ユーザーが自分の投稿した句やお題を一目で判別できるように、タグによる表示機能を追加しました。
これにより、一覧画面や詳細画面で自分の投稿をすぐに識別できるようになり、
ユーザーエクスペリエンスが向上しました。

## 実装内容
### 句の表示改善
- 「自分が詠んだ句」タグの追加（緑色）
- 一覧画面、詳細画面、お題詳細画面での表示対応
- ログインユーザーの投稿のみに表示される条件分岐の実装

### お題の表示改善
- 「自分が投稿したお題」タグの追加（水色）
- お題一覧画面と詳細画面での表示対応
- ログインユーザーの投稿のみに表示される条件分岐の実装

### デザインの統一
- 句のタグは`bg-success`クラスを使用（緑色）
- お題のタグは`bg-info`クラスを使用（水色）
- 既存のタグデザインとの整合性確保

## 動作確認項目
1. [x] 句のタグ表示
   - 一覧画面での表示
   - 詳細画面での表示
   - お題詳細画面内の句での表示
2. [x] お題のタグ表示
   - お題一覧画面での表示
   - お題詳細画面での表示
3. [x] 権限に応じた表示制御
   - ログイン時の自分の投稿のみ表示
   - 未ログイン時に表示されないことを確認
   - 他ユーザーの投稿に表示されないことを確認

## 技術的変更点
- タグ表示のための条件分岐追加
- Bootstrapの標準クラスを使用したスタイリング
- 既存のビューテンプレートの更新

## テスト実施内容
- ログイン・未ログイン状態での表示確認
- 異なるユーザーの投稿での表示確認
- 一覧・詳細画面での表示確認
- レスポンシブデザインでの表示確認

## 影響範囲
- 句の一覧・詳細表示
- お題の一覧・詳細表示
- 投稿済み句の表示部分

## 今後の展開
- タグのデザイン改善の検討
- タグのクリックによるフィルタリング機能の検討
- マイページでのタグ付き投稿の一覧表示の検討