### PR TITLE
縦書き・横書きの一斉切り替え機能の追加とプロフィール画面のリニューアル

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,8 @@ gem "dotenv-rails"
 
 gem "active_storage_validations"
 
+gem "kaminari"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,18 @@ GEM
     json (2.8.2)
     jwt (2.9.3)
       base64
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     logger (1.6.1)
     loofah (2.23.1)
       crass (~> 1.0.2)
@@ -298,6 +310,7 @@ DEPENDENCIES
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails
+  kaminari
   mini_magick
   pg (~> 1.1)
   puma (~> 5.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,0 +1,113 @@
+// Entry point for your Sass build
+@import "bootstrap";
+
+// 全体のレイアウト
+body {
+  min-height: 100vh;
+  padding-top: 64px; // ヘッダーの高さ分
+  position: relative;
+  
+  // 開発環境用のスタイル
+  &.development {
+    // Debug情報用の余白を確保
+    margin-bottom: 300px;
+  }
+}
+
+// ヘッダー
+.header {
+  background-color: #ffffff;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1030;
+  height: 64px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.header-content {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  writing-mode: horizontal-tb !important;
+}
+
+// メインコンテンツ
+.main-content-wrapper {
+  min-height: calc(100vh - 64px);
+  width: 100%;
+  position: relative;
+}
+
+// コンテナー
+.container {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+  position: relative;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+// 切り替えボタンのコンテナー
+.direction-toggle-container {
+  height: 38px;
+  margin-bottom: 1rem;
+  writing-mode: horizontal-tb !important;
+}
+
+// アラート
+.alert-wrapper {
+  position: relative;
+  z-index: 1020;
+  margin-bottom: 0;
+  width: 100%;
+}
+
+.alert {
+  margin-bottom: 0;
+  border-radius: 0;
+}
+
+// 縦書き/横書きのスタイル
+.post-content {
+  margin: 1rem 0;
+  
+  &.vertical-text {
+    writing-mode: vertical-rl;
+    text-orientation: upright;
+    height: 300px;
+    overflow-x: auto;
+    padding: 1rem;
+    margin: 1rem auto;
+  }
+
+  &.horizontal-text {
+    writing-mode: horizontal-tb;
+    padding: 1rem;
+  }
+}
+
+// カード内のコンテンツ
+.card {
+  overflow: hidden;
+  
+  &-body {
+    position: relative;
+  }
+}
+
+// writing-modeの影響を受けないようにする要素
+.header,
+.header *,
+.direction-toggle-container,
+.direction-toggle-container *,
+.alert,
+.alert *,
+.badge,
+.btn,
+.nav-link {
+  writing-mode: horizontal-tb !important;
+}

--- a/app/assets/stylesheets/header.css
+++ b/app/assets/stylesheets/header.css
@@ -1,0 +1,33 @@
+.header {
+  background-color: #ffffff;
+  border-bottom: 1px solid #e5e7eb;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1030;
+  height: 64px;
+  writing-mode: horizontal-tb !important;
+}
+
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.header-left {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.header-right {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}

--- a/app/assets/stylesheets/post_content.scss
+++ b/app/assets/stylesheets/post_content.scss
@@ -1,0 +1,35 @@
+.post-content {
+  &.vertical-text {
+    writing-mode: vertical-rl;
+    text-orientation: upright;
+    padding: 1rem;
+    margin: 0 auto;
+    height: 300px;
+    overflow-x: auto;
+  }
+
+  &.horizontal-text {
+    writing-mode: horizontal-tb;
+    padding: 1rem;
+  }
+
+  /* スクロールバーのスタイリング */
+  &::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: #888;
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: #555;
+  }
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,12 +7,15 @@ class PostsController < ApplicationController
 
   def index
     begin
-      @posts = Post.includes(:user, :tags, :image_post, theme: [:image_attachment]).order(created_at: :desc).to_a
+      @posts = Post.includes(:user, :tags, :image_post, theme: [:image_attachment])
+                   .order(created_at: :desc)
+                   .page(params[:page])
+                   .per(10)
       @image_post = ImagePost.find_by(id: session[:image_post_id]) if session[:image_post_id]
     rescue => e
       logger.error "Error in posts#index: #{e.message}"
       logger.error e.backtrace.join("\n")
-      @posts = []
+      @posts = Post.none.page(params[:page])
       flash.now[:alert] = "投稿の取得中にエラーが発生しました"
     end
   end

--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -3,18 +3,13 @@ class ThemesController < ApplicationController
   before_action :set_theme, only: [:show, :write]
 
   def index
-    @themes = Theme.all.order(created_at: :desc)
+    @themes = Theme.all.order(created_at: :desc).page(params[:page]).per(10)
   end
 
   def show
     @theme = Theme.includes(:user, posts: [:user, :tags]).find(params[:id])
     @posts = Post.where(theme_id: @theme.id).includes(:user, :tags).order(created_at: :desc)
     @original_post = Post.where(theme_id: @theme.id).order(created_at: :asc).first
-    
-    logger.debug "Theme ID: #{@theme.id}"
-    logger.debug "Theme posts count: #{@posts.size}"
-    logger.debug "Posts IDs: #{@posts.map { |p| "#{p.id} (#{p.created_at})" }}"
-    logger.debug "Original post: #{@original_post&.id} (#{@original_post&.created_at})"
   end
 
   def new
@@ -59,6 +54,11 @@ class ThemesController < ApplicationController
       logger.error e.backtrace.join("\n")
       redirect_to @theme, alert: '削除中にエラーが発生しました'
     end
+  end
+
+  def user_themes
+    @user = User.find(params[:id])
+    @themes = @user.themes.order(created_at: :desc).page(params[:page]).per(10)
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,6 +15,11 @@ class UsersController < ApplicationController
     end
   end
 
+  def posts
+    @user = User.find(params[:id])
+    @posts = @user.posts.order(created_at: :desc).page(params[:page]).per(10)
+  end
+
   private
 
   def user_params

--- a/app/javascript/controllers/text_direction_controller.js
+++ b/app/javascript/controllers/text_direction_controller.js
@@ -2,51 +2,58 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["content", "toggle"]
+  static values = {
+    direction: String
+  }
 
   connect() {
-    console.log("Text Direction Controller connected")
-    console.log("Content targets:", this.contentTargets.length)
     this.loadDirection()
+    // ページ読み込み時に現在の方向を設定
+    this.updateAllPages()
   }
 
   loadDirection() {
-    try {
-      this.direction = localStorage.getItem('textDirection') || 'vertical'
-      console.log("Loading direction:", this.direction)
-      this.updateDirection()
-    } catch (error) {
-      console.error("Error loading direction:", error)
-    }
+    this.direction = localStorage.getItem('textDirection') || 'vertical'
+    this.updateDirection()
   }
 
   toggle() {
-    try {
-      console.log("Toggle clicked. Current direction:", this.direction)
-      this.direction = this.direction === 'vertical' ? 'horizontal' : 'vertical'
-      localStorage.setItem('textDirection', this.direction)
-      this.updateDirection()
-    } catch (error) {
-      console.error("Error toggling direction:", error)
-    }
+    this.direction = this.direction === 'vertical' ? 'horizontal' : 'vertical'
+    localStorage.setItem('textDirection', this.direction)
+    // 切り替え時に全ページの要素を更新
+    this.updateAllPages()
   }
 
   updateDirection() {
-    try {
-      console.log("Updating direction to:", this.direction)
-      console.log("Content targets found:", this.contentTargets.length)
-      
-      this.contentTargets.forEach((element, index) => {
-        console.log(`Updating target ${index}:`, element)
-        element.classList.remove('vertical-text', 'horizontal-text')
-        element.classList.add(`${this.direction}-text`)
-      })
+    // このコントローラーの配下の要素を更新
+    this.contentTargets.forEach(element => {
+      element.classList.remove('vertical-text', 'horizontal-text')
+      element.classList.add(`${this.direction}-text`)
+    })
 
-      if (this.hasToggleTarget) {
-        this.toggleTarget.textContent = 
-          this.direction === 'vertical' ? '横書きに切り替え' : '縦書きに切り替え'
-      }
-    } catch (error) {
-      console.error("Error in updateDirection:", error)
+    // ボタンのテキストを更新
+    if (this.hasToggleTarget) {
+      this.toggleTarget.textContent = 
+        this.direction === 'vertical' ? '横書きに切り替え' : '縦書きに切り替え'
     }
+  }
+
+  updateAllPages() {
+    // documentのすべてのpost-content要素を取得して更新
+    document.querySelectorAll('.post-content').forEach(element => {
+      element.classList.remove('vertical-text', 'horizontal-text')
+      element.classList.add(`${this.direction}-text`)
+    })
+
+    // すべての切り替えボタンのテキストを更新
+    document.querySelectorAll('[data-text-direction-target="toggle"]').forEach(button => {
+      button.textContent = this.direction === 'vertical' ? '横書きに切り替え' : '縦書きに切り替え'
+    })
+
+    // カスタムイベントを発行して他のコントローラーに通知
+    const event = new CustomEvent('textDirectionChange', { 
+      detail: { direction: this.direction }
+    })
+    window.dispatchEvent(event)
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,52 +6,68 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload", media: "all", as: "style" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
     <%= yield :page_javascript %>
-
-    <style>
-      .back-button {
-        display: inline-block;
-        padding: 0.5rem 1rem;
-        position: relative;
-        transition: opacity 0.2s ease-in-out;
-      }
-      
-      .back-button.loading {
-        opacity: 0.5;
-        pointer-events: none;
-      }
-      
-      .back-button.loading::after {
-        content: '';
-        position: absolute;
-        right: -1.5rem;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 1rem;
-        height: 1rem;
-        border: 2px solid rgba(59, 130, 246, 0.5);
-        border-top-color: transparent;
-        border-radius: 50%;
-        animation: spin 0.6s linear infinite;
-      }
-      
-      @keyframes spin {
-        to { transform: translateY(-50%) rotate(360deg); }
-      }
-    </style>
   </head>
 
   <body>
-    <%= render 'shared/header' %>
+    <div class="page-wrapper" data-controller="text-direction">
+      <header class="header">
+        <div class="container">
+          <div class="header-content">
+            <div class="header-left">
+              <%= link_to 'ホーム', root_path, class: 'button' %>
+              <% if logged_in? %>
+                <%= link_to '句一覧', posts_path, class: 'button' %>
+                <%= link_to 'お題一覧', themes_path, class: 'button' %>
+              <% end %>
+            </div>
 
-    <% flash.each do |key, value| %>
-      <div class="alert alert-<%= key == 'notice' ? 'success' : 'danger' %>">
-        <%= value %>
-      </div>
-    <% end %>
+            <div class="header-right">
+              <% if logged_in? %>
+                <%= link_to profile_path, class: 'text-decoration-none text-dark' do %>
+                  <span class="fw-medium"><%= current_user.name %></span>
+                <% end %>
+                <%= link_to '句を詠む', new_image_post_path, class: 'button button-success ms-3' %>
+              <% else %>
+                <%= link_to 'ログイン', login_path, class: 'button' %>
+                <%= link_to '新規登録', signup_path, class: 'button' %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </header>
 
-    <%= yield %>
+      <% if flash.any? %>
+        <div class="alert-wrapper">
+          <% flash.each do |key, value| %>
+            <div class="alert alert-<%= key == 'notice' ? 'success' : 'danger' %> text-center">
+              <%= value %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
+      <main class="main-content-wrapper">
+        <% if content_for?(:with_direction_toggle) %>
+          <div class="container">
+            <div class="direction-toggle-container text-end">
+              <button type="button"
+                      data-text-direction-target="toggle"
+                      data-action="click->text-direction#toggle"
+                      class="btn btn-outline-secondary">
+                縦書き/横書き切り替え
+              </button>
+            </div>
+            <%= yield %>
+          </div>
+        <% else %>
+          <div class="container">
+            <%= yield %>
+          </div>
+        <% end %>
+      </main>
+    </div>
   </body>
 </html>

--- a/app/views/posts/confirm.html.erb
+++ b/app/views/posts/confirm.html.erb
@@ -1,69 +1,62 @@
-<div class="container" data-controller="text-direction">
-  <div class="text-end mb-3">
-    <button type="button"
-            data-text-direction-target="toggle"
-            data-action="click->text-direction#toggle"
-            class="btn btn-outline-secondary">
-      縦書き/横書き切り替え
-    </button>
-  </div>
+<% content_for :with_direction_toggle, true %>
 
-  <div class="row justify-content-center">
-    <div class="col-md-8">
-      <h1 class="text-center mb-4">投稿内容の確認</h1>
+<div class="row justify-content-center">
+  <div class="col-md-8">
+    <h1 class="text-center mb-4">投稿内容の確認</h1>
 
-      <% if @theme %>
-        <div class="card mb-4">
-          <div class="card-body">
-            <%= image_tag @theme.image, class: "w-100 rounded-lg" if @theme.image.attached? %>
-            <p class="mt-2 text-muted"><%= @theme.description %></p>
-          </div>
-        </div>
-      <% elsif @image_post&.image.present? %>
-        <div class="card mb-4">
-          <div class="card-body">
-            <h2 class="h5 mb-3">選択した画像</h2>
-            <%= image_tag url_for(@image_post.image), class: "w-100 rounded-lg" %>
-            <% if @image_post.description.present? %>
-              <p class="mt-2 text-muted"><%= @image_post.description %></p>
+    <div class="card mb-4">
+      <div class="card-body">
+        <% if @post.image_post.present? && @post.image_post.image.present? %>
+          <div class="mb-4">
+            <div class="image-container">
+              <%= image_tag @post.image_post.image, class: "w-100 rounded-lg" %>
+            </div>
+            <% if @post.image_post.description.present? %>
+              <p class="mt-2 text-muted"><%= @post.image_post.description %></p>
             <% end %>
           </div>
-        </div>
-      <% end %>
-      
-      <div class="card mb-4">
-        <div class="card-body">
-          <div class="mb-4">
-            <h2 class="h5 mb-2">種類</h2>
-            <p class="mb-0"><%= @tag&.name %></p>
-          </div>
-
-          <div class="mb-4">
-            <h2 class="h5 mb-2">読み方</h2>
-            <p class="mb-0"><%= @post&.reading %></p>
-          </div>
-
-          <div class="mb-4">
-            <h2 class="h5 mb-2">本文</h2>
-            <%= render partial: 'post_content', locals: { content: @post&.display_content } %>
-          </div>
-        </div>
-      </div>
-
-      <div class="text-center mt-4">
-        <%= form_with(model: @post, local: true, class: 'd-inline') do |f| %>
-          <%= f.hidden_field :reading %>
-          <%= f.hidden_field :display_content %>
-          <%= f.submit "投稿する", class: "button button-primary me-2" %>
         <% end %>
-        <%= link_to "本文を修正", new_content_posts_path, class: "button me-2" %>
-        <%= link_to "読み方を修正", new_reading_posts_path, class: "button me-2" %>
-        <%= link_to "種類を修正", new_type_posts_path, class: "button me-2" %>
-        <% if @theme %>
-          <%= link_to "お題の選択に戻る", themes_path, class: "button" %>
-        <% else %>
-          <%= link_to "画像を修正", new_image_post_path, class: "button" %>
+
+        <% if @post.theme.present? %>
+          <div class="mb-4">
+            <% if @post.theme.image.attached? %>
+              <div class="image-container">
+                <%= image_tag @post.theme.image, class: "w-100 rounded-lg" %>
+              </div>
+            <% end %>
+            <p class="mt-2 text-muted"><%= @post.theme.description %></p>
+          </div>
         <% end %>
+
+        <div class="d-flex justify-content-between align-items-start mb-3">
+          <span class="badge bg-primary"><%= @post.tags.first&.name %></span>
+        </div>
+
+        <%= render partial: 'posts/post_content', locals: { content: @post.display_content } %>
+
+        <div class="d-flex justify-content-between mt-4">
+          <%= button_to '戻る', { action: 'new_content' }, 
+              method: :get,
+              params: { 
+                content: @post.content,
+                theme_id: @post.theme_id,
+                tag: @post.tags.first&.name,
+                image_post: @post.image_post&.attributes&.slice('description')
+              },
+              class: 'button' %>
+
+          <%= button_to '投稿する',
+              { action: 'create' },
+              method: :post,
+              params: { 
+                content: @post.content,
+                theme_id: @post.theme_id,
+                tag: @post.tags.first&.name,
+                image_post: @post.image_post&.attributes&.slice('description')
+              },
+              class: 'button button-primary',
+              form: { data: { turbo: false } } %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,60 +1,55 @@
-<div class="container" data-controller="text-direction">
-  <div class="text-end mb-3">
-    <button type="button"
-            data-text-direction-target="toggle"
-            data-action="click->text-direction#toggle"
-            class="btn btn-outline-secondary">
-      縦書き/横書き切り替え
-    </button>
-  </div>
+<% content_for :with_direction_toggle, true %>
 
-  <div class="row justify-content-center">
-    <div class="col-md-8">
-      <h1 class="text-center mb-4">句一覧</h1>
-      <% if @posts.present? %>
-        <% @posts.each do |post| %>
-          <div class="card mb-3">
-            <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
-              <div class="card-body">
-                <% if post.theme.present? %>
-                  <div class="mb-4">
-                    <% if post.theme.image.attached? %>
-                      <div class="image-container-small">
-                        <%= image_tag post.theme.image, class: "w-100 rounded-lg theme-image-small" %>
-                      </div>
-                    <% end %>
-                    <p class="mt-2 text-muted"><%= post.theme.description %></p>
-                  </div>
-                <% elsif post.image_post&.image.present? %>
-                  <div class="mb-4">
+<div class="row justify-content-center">
+  <div class="col-md-8">
+    <h1 class="text-center mb-4">句一覧</h1>
+    <% if @posts.present? %>
+      <% @posts.each do |post| %>
+        <div class="card mb-3">
+          <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
+            <div class="card-body">
+              <% if post.theme.present? %>
+                <div class="mb-4">
+                  <% if post.theme.image.attached? %>
                     <div class="image-container-small">
-                      <%= image_tag post.image_post.image, class: "w-100 rounded-lg theme-image-small" %>
+                      <%= image_tag post.theme.image, class: "w-100 rounded-lg theme-image-small" %>
                     </div>
-                    <% if post.image_post.description.present? %>
-                      <p class="mt-2 text-muted"><%= post.image_post.description %></p>
-                    <% end %>
-                  </div>
-                <% end %>
-                
-                <div class="d-flex justify-content-between align-items-start mb-2">
-                  <div class="tags">
-                    <% post.tags.each do |tag| %>
-                      <span class="badge bg-primary me-1"><%= tag.name %></span>
-                    <% end %>
-                    <% if logged_in? && current_user == post.user %>
-                      <span class="badge bg-success me-1">自分が詠んだ句</span>
-                    <% end %>
-                  </div>
-                  <small class="text-muted"><%= l post.created_at, format: :long %></small>
+                  <% end %>
+                  <p class="mt-2 text-muted"><%= post.theme.description %></p>
                 </div>
-                <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
+              <% elsif post.image_post&.image.present? %>
+                <div class="mb-4">
+                  <div class="image-container-small">
+                    <%= image_tag post.image_post.image, class: "w-100 rounded-lg theme-image-small" %>
+                  </div>
+                  <% if post.image_post.description.present? %>
+                    <p class="mt-2 text-muted"><%= post.image_post.description %></p>
+                  <% end %>
+                </div>
+              <% end %>
+              
+              <div class="d-flex justify-content-between align-items-start mb-2">
+                <div class="tags">
+                  <% post.tags.each do |tag| %>
+                    <span class="badge bg-primary me-1"><%= tag.name %></span>
+                  <% end %>
+                  <% if logged_in? && current_user == post.user %>
+                    <span class="badge bg-success me-1">自分が詠んだ句</span>
+                  <% end %>
+                </div>
+                <small class="text-muted"><%= l post.created_at, format: :long %></small>
               </div>
-            <% end %>
-          </div>
-        <% end %>
-      <% else %>
-        <p class="text-center text-muted">投稿された句はありません。</p>
+              <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
+            </div>
+          <% end %>
+        </div>
       <% end %>
+    <% else %>
+      <p class="text-center text-muted">投稿された句はありません。</p>
+    <% end %>
+
+    <div class="mt-4">
+      <%= paginate @posts %>
     </div>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,64 +1,50 @@
-<div class="container" data-controller="text-direction">
-  <div class="text-end mb-3">
-    <button type="button"
-            data-text-direction-target="toggle"
-            data-action="click->text-direction#toggle"
-            class="btn btn-outline-secondary">
-      縦書き/横書き切り替え
-    </button>
-  </div>
+<% content_for :with_direction_toggle, true %>
 
-  <div class="row justify-content-center">
-    <div class="col-md-8">
-      <div class="card mb-3">
-        <div class="card-body">
-          <% if @post.theme.present? || @theme.present? %>
-            <div class="mb-4">
-              <% theme = @post.theme || @theme %>
-              <%= image_tag theme.image, class: "w-100 rounded-lg" if theme.image.attached? %>
-              <p class="mt-2 text-muted"><%= theme.description %></p>
-              <% if logged_in? && theme.available_for?(current_user) %>
-                <%= link_to 'このお題で詠む', new_type_theme_posts_path(theme), 
-                  class: "button button-primary mt-2 d-block text-center" %>
-              <% end %>
+<div class="row justify-content-center">
+  <div class="col-md-8">
+    <div class="card mb-3">
+      <div class="card-body">
+        <div class="mb-4">
+          <% if @post.theme.present? %>
+            <% if @post.theme.image.attached? %>
+              <div class="image-container">
+                <%= image_tag @post.theme.image, class: "w-100 rounded-lg" %>
+              </div>
+            <% end %>
+            <p class="mt-2 text-muted"><%= @post.theme.description %></p>
+          <% elsif @post.image_post&.image.present? %>
+            <div class="image-container">
+              <%= image_tag @post.image_post.image, class: "w-100 rounded-lg" %>
             </div>
-          <% elsif @post.image_post.present? %>
-            <div class="mb-4">
-              <% if @post.image_post.image.attached? %>
-                <%= image_tag url_for(@post.image_post.image), class: "w-100 rounded-lg" %>
-              <% end %>
-              <% if @post.image_post.description.present? %>
-                <p class="mt-2 text-muted"><%= @post.image_post.description %></p>
-              <% end %>
-            </div>
+            <% if @post.image_post.description.present? %>
+              <p class="mt-2 text-muted"><%= @post.image_post.description %></p>
+            <% end %>
           <% end %>
 
-          <%= render partial: 'post_content', locals: { content: @post.display_content } %>
-          <p class="card-text text-muted"><small>読み：<%= @post.reading %></small></p>
-
-          <div class="post-tags mt-2">
-            <% @post.tags.each do |tag| %>
-              <span class="badge bg-secondary"><%= tag.name %></span>
-            <% end %>
-            <% if logged_in? && current_user == @post.user %>
-              <span class="badge bg-success">自分が詠んだ句</span>
-            <% end %>
+          <div class="d-flex justify-content-between align-items-start mt-3">
+            <div>
+              <span class="badge bg-primary me-1"><%= @post.tags.first&.name %></span>
+              <% if logged_in? && current_user == @post.user %>
+                <span class="badge bg-success me-1">自分が詠んだ句</span>
+              <% end %>
+            </div>
+            <small class="text-muted"><%= l @post.created_at, format: :long %></small>
           </div>
-          
-          <small class="text-muted d-block mt-2"><%= l @post.created_at, format: :long %></small>
-          
-          <% if logged_in? && current_user == @post.user %>
-            <div class="mt-3">
-              <%= button_to '削除', post_path(@post), 
-                  method: :delete, 
-                  data: { turbo_confirm: "この句を削除してもよろしいですか？" },
-                  class: 'button button-danger w-100' %>
-            </div>
-          <% end %>
         </div>
-      </div>
 
-      <%= render 'shared/back_button', fallback_path: posts_path %>
+        <%= render partial: 'posts/post_content', locals: { content: @post.display_content } %>
+
+        <% if logged_in? && current_user == @post.user %>
+          <div class="mt-3">
+            <%= button_to '削除', post_path(@post), 
+                method: :delete, 
+                form: { data: { turbo_confirm: '本当に削除してもよろしいですか？' } },
+                class: 'button button-danger' %>
+          </div>
+        <% end %>
+      </div>
     </div>
+
+    <%= render 'shared/back_button', fallback_path: posts_path %>
   </div>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,44 +1,42 @@
-<div class="container mt-4">
-  <div class="row justify-content-center">
-    <div class="col-md-8">
-      <h2 class="mb-4 h4">マイページ</h2>
+<% content_for :with_direction_toggle, true %>
 
-      <div class="card mb-4">
-        <div class="card-body">
-          <h3 class="h5 mb-4">プロフィール情報</h3>
-          <div class="mb-3">
-            <p class="text-muted small mb-1">ユーザー名</p>
-            <p><%= @user.name %></p>
-          </div>
-          <div class="mb-3">
-            <p class="text-muted small mb-1">メールアドレス</p>
-            <p><%= @user.email %></p>
-          </div>
-          <div class="mt-4 d-flex gap-2 flex-wrap">
-            <%= link_to '編集', edit_profile_path, class: 'button' %>
-            <%= link_to 'パスワード変更', password_profile_path, class: 'button' %>
-            <%= button_to 'ログアウト', 
-                logout_path, 
-                method: :delete,
-                class: 'button',
-                data: { turbo: true } %>
-          </div>
+<div class="row justify-content-center">
+  <div class="col-md-8">
+    <h2 class="mb-4 h4">マイページ</h2>
+
+    <div class="card mb-4">
+      <div class="card-body">
+        <h3 class="h5 mb-4">プロフィール情報</h3>
+        <div class="mb-3">
+          <p class="text-muted small mb-1">ユーザー名</p>
+          <p><%= @user.name %></p>
+        </div>
+        <div class="mb-3">
+          <p class="text-muted small mb-1">メールアドレス</p>
+          <p><%= @user.email %></p>
+        </div>
+        <div class="mt-4 d-flex gap-2 flex-wrap">
+          <%= link_to '編集', edit_profile_path, class: 'button' %>
+          <%= link_to 'パスワード変更', password_profile_path, class: 'button' %>
+          <%= button_to 'ログアウト', 
+              logout_path, 
+              method: :delete,
+              class: 'button',
+              data: { turbo: true } %>
         </div>
       </div>
+    </div>
 
-      <div data-controller="text-direction">
-        <div class="text-end mb-3">
-          <button type="button"
-                  data-text-direction-target="toggle"
-                  data-action="click->text-direction#toggle"
-                  class="btn btn-outline-secondary btn-sm">
-            縦書き/横書き切り替え
-          </button>
-        </div>
+    <div>
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h3 class="h5 mb-0">投稿した句一覧</h3>
+        <%= link_to "すべての句を見る (#{@posts.count})", posts_user_path(@user), 
+            class: "text-decoration-none" %>
+      </div>
 
-        <h3 class="h5 mb-4">投稿した句一覧</h3>
+      <% if @posts.exists? %>
         <div class="grid gap-4">
-          <% @posts.each do |post| %>
+          <% @posts.limit(3).each do |post| %>
             <div class="card mb-4">
               <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
                 <div class="card-body">
@@ -60,16 +58,32 @@
             </div>
           <% end %>
         </div>
+      <% else %>
+        <p class="text-center text-muted">まだ句を投稿していません</p>
+      <% end %>
+    </div>
+
+    <div class="mb-4">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h3 class="h5 mb-0">作成したお題一覧</h3>
+        <%= link_to "すべてのお題を見る (#{@user.themes.count})", themes_user_path(@user), 
+            class: "text-decoration-none" %>
       </div>
 
-      <div class="card mt-4">
-        <div class="card-body text-center">
-          <%= button_to '退会する', 
-              deactivate_registration_path,
-              method: :delete,
-              class: 'button button-danger',
-              data: { turbo_confirm: '本当に退会してもよろしいですか？' } %>
-        </div>
+      <% if @user.themes.exists? %>
+        <%= render partial: 'themes/theme', collection: @user.themes.order(created_at: :desc).limit(3) %>
+      <% else %>
+        <p class="text-center text-muted">まだお題を作成していません</p>
+      <% end %>
+    </div>
+
+    <div class="card mb-4">
+      <div class="card-body text-center">
+        <%= button_to '退会する', 
+            deactivate_registration_path,
+            method: :delete,
+            class: 'button button-danger',
+            data: { turbo_confirm: '本当に退会してもよろしいですか？' } %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="header">
-  <div class="header-content mx-auto px-3">
+  <div class="header-content">
     <div class="header-left">
       <%= link_to 'ホーム', root_path, class: 'button' %>
       <% if logged_in? %>
@@ -10,12 +10,10 @@
 
     <div class="header-right">
       <% if logged_in? %>
-        <div class="mr-4">
-          <%= link_to profile_path, class: 'text-gray-700 hover:text-gray-900' do %>
-            <span class="font-medium"><%= current_user.name %></span>
-          <% end %>
-        </div>
-        <%= link_to '句を詠む', new_image_post_path, class: 'button button-success' %>
+        <%= link_to profile_path, class: 'text-decoration-none text-dark' do %>
+          <span class="fw-medium"><%= current_user.name %></span>
+        <% end %>
+        <%= link_to '句を詠む', new_image_post_path, class: 'button button-success ms-3' %>
       <% else %>
         <%= link_to 'ログイン', login_path, class: 'button' %>
         <%= link_to '新規登録', signup_path, class: 'button' %>

--- a/app/views/themes/_theme.html.erb
+++ b/app/views/themes/_theme.html.erb
@@ -1,0 +1,30 @@
+<div class="card mb-4">
+  <%= link_to theme_path(theme), class: "text-decoration-none", data: { turbo: false } do %>
+    <div class="card-body">
+      <% if theme.image.attached? %>
+        <%= image_tag theme.image, class: "w-100 rounded-lg mb-3" %>
+      <% end %>
+      
+      <div class="mb-3">
+        <p class="text-muted"><%= theme.description %></p>
+        <% if logged_in? && current_user == theme.user %>
+          <span class="badge bg-info">自分が投稿したお題</span>
+        <% end %>
+      </div>
+
+      <div class="d-flex justify-content-between align-items-center">
+        <small class="text-muted">
+          <%= l theme.created_at, format: :long %>
+          <span class="ms-2">投稿数: <%= theme.posts.count %></span>
+        </small>
+      </div>
+      
+      <% if logged_in? && theme.available_for?(current_user) && current_user != theme.user %>
+        <div class="mt-2">
+          <%= link_to 'このお題で詠む', new_type_theme_posts_path(theme), 
+              class: "button button-primary d-block text-center" %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/themes/index.html.erb
+++ b/app/views/themes/index.html.erb
@@ -1,34 +1,16 @@
-<div class="container">
-  <h1 class="text-center mb-4">お題一覧</h1>
-
-  <div class="row justify-content-center">
-    <div class="col-md-8">
+<div class="row justify-content-center">
+  <div class="col-md-8">
+    <h1 class="text-center mb-4">お題一覧</h1>
+    <% if @themes.present? %>
       <% @themes.each do |theme| %>
-        <div class="card mb-3">
-          <%= link_to theme_path(theme), class: "text-decoration-none", data: { turbo: false } do %>
-            <div class="card-body">
-              <% if theme.image.attached? %>
-                <div class="image-container-large">
-                  <%= image_tag theme.image, class: "w-100 rounded-lg theme-image-large" %>
-                </div>
-              <% end %>
-              
-              <div class="mt-2">
-                <p class="text-muted"><%= theme.description %></p>
-                <% if logged_in? && current_user == theme.user %>
-                  <span class="badge bg-info">自分が投稿したお題</span>
-                <% end %>
-              </div>
-
-              <div class="d-flex justify-content-between align-items-start mt-2">
-                <small class="text-muted">
-                  <%= l theme.created_at, format: :long %>
-                </small>
-              </div>
-            </div>
-          <% end %>
-        </div>
+        <%= render partial: 'themes/theme', locals: { theme: theme } %>
       <% end %>
+    <% else %>
+      <p class="text-center text-muted">お題はまだありません</p>
+    <% end %>
+
+    <div class="mt-4">
+      <%= paginate @themes %>
     </div>
   </div>
 </div>

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -1,64 +1,65 @@
-<div class="container" data-controller="text-direction">
-  <div class="text-end mb-3">
-    <button type="button"
-            data-text-direction-target="toggle"
-            data-action="click->text-direction#toggle"
-            class="btn btn-outline-secondary">
-      縦書き/横書き切り替え
-    </button>
-  </div>
+<% content_for :with_direction_toggle, true %>
 
-  <div class="row justify-content-center">
-    <div class="col-md-8">
-      <div class="card mb-3">
-        <div class="card-body">
-          <% if @theme.image.attached? %>
-            <%= image_tag @theme.image, class: "w-100 rounded-lg" %>
+<div class="row justify-content-center">
+  <div class="col-md-8">
+    <div class="card mb-3">
+      <div class="card-body">
+        <% if @theme.image.attached? %>
+          <%= image_tag @theme.image, class: "w-100 rounded-lg" %>
+        <% end %>
+        
+        <div class="mt-2">
+          <p class="text-muted"><%= @theme.description %></p>
+          <% if logged_in? && current_user == @theme.user %>
+            <span class="badge bg-info">自分が投稿したお題</span>
           <% end %>
-          
+        </div>
+        
+        <% if logged_in? && @theme.available_for?(current_user) && current_user != @theme.user %>
+          <%= link_to 'このお題で詠む', new_type_theme_posts_path(@theme), 
+              class: "button button-primary mt-2 d-block text-center" %>
+        <% elsif logged_in? && @theme.posted_by?(current_user) && current_user != @theme.user %>
+          <div class="alert alert-info mt-2">
+            このお題では既に句を詠んでいます
+          </div>
+        <% end %>
+
+        <% if logged_in? && current_user == @theme.user %>
           <div class="mt-2">
-            <p class="text-muted"><%= @theme.description %></p>
-            <% if logged_in? && current_user == @theme.user %>
-              <span class="badge bg-info">自分が投稿したお題</span>
+            <%= button_to '削除', theme_path(@theme), 
+                method: :delete,
+                data: { turbo_confirm: "このお題を削除してもよろしいですか？\n（このお題で詠まれた句は削除されません）" },
+                class: 'button button-danger' %>
+          </div>
+        <% end %>
+
+        <div class="mt-4">
+          <h2 class="h4 mb-4">このお題で詠まれた句</h2>
+          <div class="grid gap-4">
+            <% @posts.each do |post| %>
+              <div class="card mb-3">
+                <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
+                  <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-start mb-2">
+                      <div class="tags">
+                        <% if post.id == @original_post&.id %>
+                          <span class="badge bg-primary me-1">最初に詠まれた句</span>
+                        <% end %>
+                        <% post.tags.each do |tag| %>
+                          <span class="badge bg-primary me-1"><%= tag.name %></span>
+                        <% end %>
+                      </div>
+                      <small class="text-muted"><%= l post.created_at, format: :long %></small>
+                    </div>
+                    <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
+                  </div>
+                <% end %>
+              </div>
             <% end %>
           </div>
-          
-          <% if logged_in? && @theme.available_for?(current_user) %>
-            <%= link_to 'このお題で詠む', new_type_theme_posts_path(@theme), 
-                class: "button button-primary mt-2 d-block text-center" %>
-          <% elsif logged_in? && @theme.posted_by?(current_user) %>
-            <div class="alert alert-info mt-2">
-              このお題では既に句を詠んでいます
-            </div>
-          <% end %>
-
-          <% if logged_in? && current_user == @theme.user %>
-            <div class="mt-2">
-              <%= button_to '削除', theme_path(@theme), 
-                  method: :delete,
-                  data: { turbo_confirm: "このお題を削除してもよろしいですか？\n（このお題で詠まれた句は削除されません）" },
-                  class: 'button button-danger' %>
-            </div>
-          <% end %>
-
-          <div class="mt-8">
-            <h2 class="text-xl font-bold mb-4">このお題で詠まれた句</h2>
-            <div class="grid gap-4">
-              <% @posts.each do |post| %>
-                <div class="relative">
-                  <% if post.id == @original_post&.id %>
-                    <span class="absolute top-0 right-0 bg-blue-500 text-white text-xs px-2 py-1 rounded-full z-10">
-                      最初に詠まれた句
-                    </span>
-                  <% end %>
-                  <%= render partial: 'posts/post', locals: { post: post } %>
-                </div>
-              <% end %>
-            </div>
-          </div>
-
-          <%= render 'shared/back_button', fallback_path: themes_path %>
         </div>
+
+        <%= render 'shared/back_button', fallback_path: themes_path %>
       </div>
     </div>
   </div>

--- a/app/views/themes/user_themes.html.erb
+++ b/app/views/themes/user_themes.html.erb
@@ -1,0 +1,21 @@
+<div class="container mt-4">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <h2 class="mb-4 h4"><%= @user.name %>さんが作成したお題一覧</h2>
+
+      <div class="grid gap-4">
+        <% if @themes.any? %>
+          <%= render partial: 'themes/theme', collection: @themes %>
+        <% else %>
+          <p class="text-center text-muted">まだお題を作成していません</p>
+        <% end %>
+      </div>
+
+      <div class="mt-4">
+        <%= paginate @themes %>
+      </div>
+
+      <%= render 'shared/back_button', fallback_path: profile_path %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/posts.html.erb
+++ b/app/views/users/posts.html.erb
@@ -1,0 +1,41 @@
+<% content_for :with_direction_toggle, true %>
+
+<div class="row justify-content-center">
+  <div class="col-md-8">
+    <h2 class="mb-4 h4"><%= @user.name %>さんの投稿一覧</h2>
+
+    <% if @posts.any? %>
+      <div class="grid gap-4">
+        <% @posts.each do |post| %>
+          <div class="card mb-4">
+            <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
+              <div class="card-body">
+                <% if post.image_post&.image.present? %>
+                  <div class="mb-4">
+                    <%= image_tag url_for(post.image_post.image), class: "w-100 rounded" %>
+                    <% if post.image_post.description.present? %>
+                      <p class="mt-2 text-muted small"><%= post.image_post.description %></p>
+                    <% end %>
+                  </div>
+                <% end %>
+                <div class="d-flex justify-content-between align-items-start mb-3">
+                  <span class="badge bg-primary"><%= post.tags.first&.name %></span>
+                  <small class="text-muted"><%= l post.created_at, format: :long %></small>
+                </div>
+                <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="mt-4">
+        <%= paginate @posts %>
+      </div>
+    <% else %>
+      <p class="text-center text-muted">まだ投稿がありません</p>
+    <% end %>
+
+    <%= render 'shared/back_button', fallback_path: profile_path %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,12 @@ Rails.application.routes.draw do
   
   get 'signup', to: 'users#new'
   post 'signup', to: 'users#create'
-  resources :users, only: [:create]
+  resources :users, only: [:create] do
+    member do
+      get 'posts'
+      get 'themes', to: 'themes#user_themes'
+    end
+  end
 
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'


### PR DESCRIPTION
# 縦書き・横書きの一斉切り替え機能の追加とプロフィール画面のリニューアル

## 概要
- ページ単位で行っていた縦書き・横書きの切り替えを、アプリ全体で一斉に切り替わるように改善
- プロフィール画面の表示を改善し、投稿した句の一覧をより見やすく整理
- 各ページで統一感のある表示を実現

## 実装内容
### 切り替え機能の改善
- LocalStorageを使用した表示設定の保存
- 複数ページでの同期切り替えの実装
 - カスタムイベントによる他コンポーネントへの通知機能
- ページ遷移後も表示設定を維持

### プロフィール画面の改善
- 句の一覧表示の最適化
 - 最新3件のみを表示し、「すべての句を見る」リンクを追加
 - 投稿件数の表示を追加
- お題一覧の表示改善
 - お題の一覧表示も最新3件に制限
 - リンク先での完全な一覧表示を実装
- レイアウトとデザインの統一
 - 句とお題で一貫性のある表示を実現
 - スペーシングとマージンの調整

### レイアウト構造の改善
- 切り替えボタンの位置を統一
- 
## 動作確認項目
1. [x] 切り替え機能の動作
  - 全ページでの切り替え反映
  - ページ遷移後の状態維持
  - 複数タブでの同期切り替え
2. [x] プロフィール画面の機能
  - 最新投稿の表示
  - 一覧へのリンク動作
  - ページネーションの動作
3. [x] レイアウトの安定性
  - 切り替え時のレイアウト維持
4. [x] 表示の一貫性
  - 各ページでの統一感
  - 切り替え時の挙動

## 技術的変更点
- text-direction_controllerの機能拡張
 - updateAllPages関数の追加
 - LocalStorageによる状態管理
- プロフィール画面の実装改善
 - 部分テンプレートの活用
 - ページネーションの実装
- CSS構造の整理
 - writing-mode関連の指定見直し
 - レイアウト階層の整理
- テンプレートの共通化（content_for）

## テスト実施内容
- 各ページでの切り替え動作確認
- プロフィール画面の表示・動作確認
- 複数タブでの同期確認
- ページ遷移時の状態維持確認
- レスポンシブ表示での確認

## 影響範囲
- 全ページの縦書き・横書き表示
- プロフィール画面の構造とデザイン
- 切り替えボタンの実装
- 投稿内容の表示部分

## 今後の展開
- ヘッダーレイアウトの調整
- 切り替えアニメーションの追加検討
- ユーザー設定との連携検討
- より安定したレイアウト制御の実装
- プロフィール画面でのフィルター機能の追加検討